### PR TITLE
`assetsPath`の末尾のスラッシュを除去する

### DIFF
--- a/packages/noise-suppression/src/noise_suppression.ts
+++ b/packages/noise-suppression/src/noise_suppression.ts
@@ -70,7 +70,8 @@ class NoiseSuppressionProcessor {
       throw Error("NoiseSuppressionProcessor has already been started.");
     }
 
-    this.rnnoise = await Rnnoise.load({ assetsPath: this.options.assetsPath || "." });
+    const assetsPath = trimLastSlash(this.options.assetsPath || ".");
+    this.rnnoise = await Rnnoise.load({ assetsPath });
     this.buffer = new Float32Array(this.rnnoise.frameSize);
 
     this.abortController = new AbortController();
@@ -178,6 +179,14 @@ class NoiseSuppressionProcessor {
     }
 
     data.close();
+  }
+}
+
+function trimLastSlash(s: string): string {
+  if (s[s.length - 1] == "/") {
+    return s.slice(0, -1);
+  } else {
+    return s;
   }
 }
 

--- a/packages/noise-suppression/src/noise_suppression.ts
+++ b/packages/noise-suppression/src/noise_suppression.ts
@@ -183,11 +183,10 @@ class NoiseSuppressionProcessor {
 }
 
 function trimLastSlash(s: string): string {
-  if (s[s.length - 1] == "/") {
+  if (s.slice(-1) === "/") {
     return s.slice(0, -1);
-  } else {
-    return s;
   }
+  return s;
 }
 
 export { NoiseSuppressionProcessor, NoiseSuppressionProcessorOptions };

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -80,7 +80,7 @@ class VirtualBackgroundProcessor {
 
     // セグメンテーションモデルの初期化
     const config: SelfieSegmentationConfig = {};
-    const assetsPath = options.assetsPath || ".";
+    const assetsPath = trimLastSlash(options.assetsPath || ".");
     config.locateFile = (file: string) => {
       return `${assetsPath}/${file}`;
     };
@@ -198,6 +198,14 @@ class VirtualBackgroundProcessor {
     }
 
     this.canvasCtx.restore();
+  }
+}
+
+function trimLastSlash(s: string): string {
+  if (s[s.length - 1] == "/") {
+    return s.slice(0, -1);
+  } else {
+    return s;
   }
 }
 

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -202,11 +202,10 @@ class VirtualBackgroundProcessor {
 }
 
 function trimLastSlash(s: string): string {
-  if (s[s.length - 1] == "/") {
+  if (s.slice(-1) === "/") {
     return s.slice(0, -1);
-  } else {
-    return s;
   }
+  return s;
 }
 
 export { VirtualBackgroundProcessorOptions, VirtualBackgroundProcessor };


### PR DESCRIPTION
現在の`develop`ブランチの挙動では、ユーザが`assetsPath`に `"https://cdn.jsdelivr.net/npm/@shiguredo/noise-suppression@latest/dist/"` のように末尾がスラッシュで終わるパス（URL）を指定した場合、内部的には `"https://cdn.jsdelivr.net/npm/@shiguredo/noise-suppression@latest/dist//rnnoise.wasm"` のようにファイル名の前にスラッシュを二重に含んだURLが生成されてしまう。
このようなURLの扱いはHTTPサーバによって変わり、例えばcdn.jsdelivr.netの場合には400エラーが返されることになる。
ユーザが末尾にスラッシュがあるかどうかを気にしなければいけないのは煩雑なので、本PRで、末尾のスラッシュは自動的に除去した上でアセット用のURLを生成するように内部挙動を変更する。
