### PR TITLE
README.md内のexampleコードが古かったので修正

### DIFF
--- a/packages/noise-suppression/README.md
+++ b/packages/noise-suppression/README.md
@@ -22,9 +22,8 @@ JavaScript/TypeScriptでノイズ抑制機能を実現するためのライブ�
 ```html
 <script>
     // wasm ファイルの配置先
-    const options = {
-        assetsPath: "https://cdn.jsdelivr.net/npm/@shiguredo/noise-suppression@latest/dist"
-    };
+    const assetsPath = "https://cdn.jsdelivr.net/npm/@shiguredo/noise-suppression@latest/dist";
+    const processor = new Shiguredo.NoiseSuppressionProcessor(assetsPath);
 
     // RNNoiseの推奨設定
     const constraints = {
@@ -33,13 +32,11 @@ JavaScript/TypeScriptでノイズ抑制機能を実現するためのライブ�
         channelCount: {exact: 1}
     }
 
-    let processor;
     navigator.mediaDevices.getUserMedia({audio: constraints}).then((stream) => {
         const track = stream.getAudioTracks()[0];
-        processor = new Shiguredo.NoiseSuppressionProcessor(track, options);
 
         // ノイズ抑制処理開始
-        processor.startProcessing().then((processed_track) => {
+        processor.startProcessing(track).then((processed_track) => {
             const audioElement = document.getElementById("outputAudio"); // 音声の出力先を取得
             audioElement.srcObject = new MediaStream([processed_track]);
         });
@@ -65,8 +62,9 @@ TypeScript での使用方法は次のようになります:
 ```typescript
 import { NoiseSuppressionProcessor } from "@shiguredo/noise-suppression";
 
-const processor = new NoiseSuppressionProcessor(original_audio_track);
-const processed_audio_track = await processor.startProcessing();
+const assetsPath = "https://cdn.jsdelivr.net/npm/@shiguredo/noise-suppression@latest/dist";
+const processor = new NoiseSuppressionProcessor(assetsPath);
+const processed_audio_track = await processor.startProcessing(original_audio_track);
 
 ...
 

--- a/packages/virtual-background/README.md
+++ b/packages/virtual-background/README.md
@@ -21,18 +21,18 @@ JavaScript/TypeScriptで仮想背景機能を実現するためのライブラ�
 背景ぼかしを行う場合は、以下のようなコードになります:
 ```html
 <script>
-    const options = {
-        blurRadius: 15,  // 背景ぼかし設定
-        assetsPath: "https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist"
-    };
+    const assetsPath = "https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist";
+    const processor = new Shiguredo.VirtualBackgroundProcessor(assetsPath);
 
-    let processor;
     navigator.mediaDevices.getUserMedia({video: true}).then((stream) => {
         const track = stream.getVideoTracks()[0];
-        processor = new Shiguredo.VirtualBackgroundProcessor(track, options);
+
+        const options = {
+            blurRadius: 15,  // 背景ぼかし設定
+        };
 
         // 仮想背景処理開始
-        processor.startProcessing().then((processed_track) => {
+        processor.startProcessing(track, options).then((processed_track) => {
             const videoElement = document.getElementById("outputVideo"); // 映像の出力先を取得
             videoElement.srcObject = new MediaStream([processed_track]);
         });
@@ -51,11 +51,8 @@ JavaScript/TypeScriptで仮想背景機能を実現するためのライブラ�
     backgroundImage.src = "/path/to/background-image";
 
     const options = {
-        backgroundImage,
-        assetsPath: "https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist/"
+        backgroundImage
     };
-
-    ...以降のコードは同様...
 </script>
 ```
 
@@ -74,8 +71,13 @@ TypeScript での使用方法は次のようになります:
 ```typescript
 import { VirtualBackgroundProcessor } from "@shiguredo/virtual-background";
 
-const processor = new VirtualBackgroundProcessor(original_video_track);
-const processed_video_track = await processor.startProcessing();
+const assetsPath = "https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@latest/dist";
+const processor = new VirtualBackgroundProcessor(assetsPath);
+
+const options = {
+    blurRadius: 15,  // 背景ぼかし設定
+};
+const processed_video_track = await processor.startProcessing(original_video_track, options);
 
 ...
 


### PR DESCRIPTION
本日に仮想背景とノイズ抑制の2022.3.0がリリースされたけれど、README内のサンプルコードが2022.2.0用のもののままだったので更新。