### PR TITLE
仮想背景処理適用中に、処理適用後のトラックを止めた場合にブラウザ上でエラーが発生する問題を修正

### DIFF
--- a/packages/noise-suppression/src/noise_suppression.ts
+++ b/packages/noise-suppression/src/noise_suppression.ts
@@ -176,8 +176,13 @@ class TrackProcessor {
       .pipeTo(generator.writable)
       .catch((e) => {
         if (signal.aborted) {
+          // NoiseSuppressor.stopProcessing() 経由で止まった場合
           console.debug("Shutting down streams after abort.");
+        } else if (generator.readyState === "ended") {
+          // generator.stop() 経由で止まった場合
+          console.debug("Processed track was closed.");
         } else {
+          // 未知の経路なので、警告ログを出しておく
           console.warn("Error from stream transform:", e);
         }
         processor.readable.cancel(e).catch((e) => {

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -217,11 +217,13 @@ class TrackProcessor {
       .pipeTo(generator.writable)
       .catch((e) => {
         if (signal.aborted) {
+          // VirtualBackground.stopProcessing() 経由で止まった場合
           console.debug("Shutting down streams after abort.");
         } else if (generator.readyState === "ended") {
+          // generator.stop() 経由で止まった場合
           console.debug("Processed track was closed.");
         } else {
-          // 未知のエラーなので、警告ログを出しておく
+          // 未知の経路なので、警告ログを出しておく
           console.warn("Error from stream transform:", e);
         }
         if (this.lastFrame !== undefined) {


### PR DESCRIPTION
# モチベーション

タイトルのような操作を行うと、以下のようなエラーが Chrome で発生するので、それを修正するための PR です。
![image](https://user-images.githubusercontent.com/181413/160526992-1dfae734-f6c7-40ea-9404-be549721d0ef.png)

なお、同様の操作をしてもノイズ抑制の方では問題は発生しませんでした。

# 再現コード

```html
<html>
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <script src="https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@2022.4.1/dist/virtual_background.js"></script>
    <script>
      const assetsPath = "https://cdn.jsdelivr.net/npm/@shiguredo/virtual-background@2022.4.1/dist";
      const processor = new Shiguredo.VirtualBackgroundProcessor(assetsPath);
      (async() => {
        const stream = await navigator.mediaDevices.getUserMedia({video: true});
        const track = stream.getVideoTracks()[0];
        const options = {
          blurRadius: 10
        };
        const processingTrack = await processor.startProcessing(track, options);
       // processor.stopProcessing();  // この行をコメントアウトするとエラーは出なくなる
        processingTrack.stop();
      })();
    </script>
  </body>
</html>
```

# 原因と修正内容

- [原因] `VirtualBackgroundProcessor.stopProcessing()` を呼ばずに、処理後のトラックの `stop()` メソッドを呼ぶと、 `controller.enqueue(frame)` で追加したフレームが未処理のまま放置されてしまう
  - エンキュー先でそれを扱うはずのトラックが既に閉じているため
  - このフレームはクローズされることもないので、最終的に GC のタイミングで冒頭のエラーが発生する
- [対応] 最後にエンキューしたフレーム、への参照を `VirtualBackgroundProcessor` インスタンスに保持しておいて、処理終了時に自前でクローズを呼び出すようにする

手元の環境では、これで現象が改善したことが確認できたが、あくまでもワークアラウンドで、いくつか微妙な点もある:
- `stopProcessing()` 呼び出しのタイミング次第では「`VirtualBackgroundProcessor`がクローズした `VideoFrame` をエンキュー先で処理しようとする（けれどクローズされているのでエラーになる）」といったレースコンディションが発生する可能性がありそう
  - ただし、この辺りの挙動は実装次第なので本当に発生する可能性があるかどうかは不明（今のところは確認できていないので杞憂かもしれない）
- 今回の修正は controller の producer と consumer のペースが一定だと仮定して、最後の一フレームのみを保持しているけれど、この仮定が成立しないケースでは、冒頭のエラーが発生し得る
  - 例えば、何らかの理由で、トラックのクローズ間際にまとめて 10 フレームがエンキューされた場合には、最後の一フレーム以外はクローズされずに残ることになるはず