### PR TITLE
仮想背景適用時に映像がチラつくことがある問題を修正

### DIFF
--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -261,6 +261,10 @@ class TrackProcessor {
       return;
     }
 
+    // `VideoFrame` の第一引数に `this.canvas` を直接渡したり、
+    // `this.canvas.transferToImageBitmap()` を使って `ImageBitmap` を取得することも可能だが、
+    // この方法だと環境によっては、透過時の背景色やぼかしの境界部分処理が変になる現象が確認できているため、
+    // ワークアラウンドとして、一度 `ImageData` を経由する方法を採用している
     const imageData = this.canvasCtx.getImageData(0, 0, this.canvas.width, this.canvas.height);
     const imageBitmap = await createImageBitmap(imageData);
     controller.enqueue(new VideoFrame(imageBitmap, { timestamp, duration } as VideoFrameInit));

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -261,8 +261,9 @@ class TrackProcessor {
       return;
     }
 
-    // @ts-ignore TS2345: 「`canvas`の型が合っていない」と怒られるけれど、動作はするので一旦無視。
-    controller.enqueue(new VideoFrame(this.canvas, { timestamp, duration }));
+    const imageData = this.canvasCtx.getImageData(0, 0, this.canvas.width, this.canvas.height);
+    const imageBitmap = await createImageBitmap(imageData);
+    controller.enqueue(new VideoFrame(imageBitmap, { timestamp, duration } as VideoFrameInit));
   }
 
   private updateOffscreenCanvas(segmentationResults: SelfieSegmentationResults) {

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -265,6 +265,9 @@ class TrackProcessor {
     // `this.canvas.transferToImageBitmap()` を使って `ImageBitmap` を取得することも可能だが、
     // この方法だと環境によっては、透過時の背景色やぼかしの境界部分処理が変になる現象が確認できているため、
     // ワークアラウンドとして、一度 `ImageData` を経由する方法を採用している
+    //
+    // `ImageData` を経由しない場合の問題としては https://bugs.chromium.org/p/chromium/issues/detail?id=961777 で
+    // 報告されているものが近そう
     const imageData = this.canvasCtx.getImageData(0, 0, this.canvas.width, this.canvas.height);
     const imageBitmap = await createImageBitmap(imageData);
     controller.enqueue(new VideoFrame(imageBitmap, { timestamp, duration } as VideoFrameInit));


### PR DESCRIPTION
仮想背景処理時には、処理中の画像を格納するための中間バッファとして `OffscreenCanvas` を利用している。

この `OffscreenCanvas` から処理後の画像を取り出して `VideoFrame` を生成する際に、直接 canvas インスタンスを指定（ないし `OffscreenCanvas. transferToImageBitmap()` で `ImageBitmap` に変換）すると、環境や入力映像の条件によっては、処理後の映像にチラつき等が発生することが確認された。

具体的な原因や発生条件は不明だが `OffscreenCanvas` から `ImageData` 経由で処理後の画像を取得することで、問題が解消することが分かったので、本 PR でそのワークアラウンドを適用する。

### 補足情報

現象としては https://bugs.chromium.org/p/chromium/issues/detail?id=961777 で報告されている問題に近そう