### PR TITLE
仮想背景画像の使用する領域を決定するためのオプションを追加

### DIFF
--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -36,9 +36,9 @@ interface VirtualBackgroundProcessorOptions {
   /**
    * 背景画像のどの領域を使用するかを決定する関数
    *
-   * 主に、背景画像と処理対象映像のアスペクト比が異なる場合に、どこをクロップするかを決めるために使用されます
+   * 背景画像と処理対象映像のアスペクト比が異なる場合の扱いを決定するために使用されます
    *
-   * デフォルトでは画像のアスペクト非を維持したまま中央部分を切り抜く {@link cropBackgroundImageCenter} が使用されます
+   * デフォルトでは、背景画像のアスペクト比を維持したまま中央部分を切り抜く {@link cropBackgroundImageCenter} が使われます
    */
   backgroundImageRegion?: (videoFrame: ImageSize, backgroundImage: ImageSize) => ImageRegion;
 }
@@ -62,9 +62,9 @@ interface ImageRegion {
 }
 
 /**
- * {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションのデフォルトの挙動
+ * 背景画像と処理対象映像のアスペクトが異なる場合に、背景画像の中央部分を切り抜いた領域を返します
  *
- * 背景画像と処理対象映像のアスペクトが異なる場合には、背景画像の中央部分を切り抜いて使用されます
+ * これは {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションのデフォルトの挙動です
  */
 function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
   let x = 0;
@@ -88,10 +88,10 @@ function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: Image
 }
 
 /**
- * {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションに指定可能な関数
+ * 常に背景画像の全領域を返します
  *
- * 背景画像の全領域を使用する。
- * 背景画像と処理対象映像のアスペクト比が異なる場合には、背景画像が引き伸ばされます。
+ * これは {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションに指定可能な関数で、
+ * 背景画像と処理対象映像のアスペクト比が異なる場合には、背景画像が映像に合わせて引き伸ばされます
  */
 function fillBackgroundImage(_videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
   return { x: 0, y: 0, width: backgroundImage.width, height: backgroundImage.height };
@@ -355,7 +355,6 @@ class TrackProcessor {
     this.canvasCtx.globalCompositeOperation = "destination-over";
     if (this.options.backgroundImage !== undefined) {
       const decideRegion = this.options.backgroundImageRegion || cropBackgroundImageCenter;
-
       const region = decideRegion(this.canvas, this.options.backgroundImage);
       this.canvasCtx.drawImage(
         this.options.backgroundImage,

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -36,11 +36,11 @@ interface VirtualBackgroundProcessorOptions {
   /**
    * 背景画像のどの領域を使用するかを決定する関数
    *
-   * 主に、背景画像と処理対象映像のアスペクト比が異なる場合に、どこをクロップするかを決めるために使用される
+   * 主に、背景画像と処理対象映像のアスペクト比が異なる場合に、どこをクロップするかを決めるために使用されます
    *
-   * デフォルトは {@link cropBackgroundImageCenter}
+   * デフォルトでは画像のアスペクト非を維持したまま中央部分を切り抜く {@link cropBackgroundImageCenter} が使用されます
    */
-  backgroundImageRegion?: (canvas: ImageSize, backgroundImage: ImageSize) => ImageRegion;
+  backgroundImageRegion?: (videoFrame: ImageSize, backgroundImage: ImageSize) => ImageRegion;
 }
 
 /**
@@ -61,20 +61,25 @@ interface ImageRegion {
   height: number;
 }
 
-function cropBackgroundImageCenter(canvas: ImageSize, backgroundImage: ImageSize): ImageRegion {
+/**
+ * {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションのデフォルトの挙動
+ *
+ * 背景画像と処理対象映像のアスペクトが異なる場合には、背景画像の中央部分を切り抜いて使用されます
+ */
+function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
   let x = 0;
   let y = 0;
   let width = backgroundImage.width;
   let height = backgroundImage.height;
 
-  const canvasRatio = canvas.width / canvas.height;
+  const videoFrameRatio = videoFrame.width / videoFrame.height;
   const backgroundImageRatio = backgroundImage.width / backgroundImage.height;
-  if (backgroundImageRatio > canvasRatio) {
-    const newHeight = canvas.height * (backgroundImage.width / canvas.width);
+  if (backgroundImageRatio > videoFrameRatio) {
+    const newHeight = videoFrame.height * (backgroundImage.width / videoFrame.width);
     y = Math.round((height - newHeight) / 2);
     height = Math.round(newHeight);
-  } else if (backgroundImageRatio < canvasRatio) {
-    const newWidth = canvas.width * (backgroundImage.height / canvas.height);
+  } else if (backgroundImageRatio < videoFrameRatio) {
+    const newWidth = videoFrame.width * (backgroundImage.height / videoFrame.height);
     x = Math.round((width - newWidth) / 2);
     width = Math.round(newWidth);
   }
@@ -83,9 +88,12 @@ function cropBackgroundImageCenter(canvas: ImageSize, backgroundImage: ImageSize
 }
 
 /**
+ * {@link VirtualBackgroundProcessorOptions.backgroundImageRegion} オプションに指定可能な関数
  *
+ * 背景画像の全領域を使用する。
+ * 背景画像と処理対象映像のアスペクト比が異なる場合には、背景画像が引き伸ばされます。
  */
-function fillBackgroundImage(_canvas: ImageSize, backgroundImage: ImageSize): ImageRegion {
+function fillBackgroundImage(_videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
   return { x: 0, y: 0, width: backgroundImage.width, height: backgroundImage.height };
 }
 

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -74,11 +74,11 @@ function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: Image
 
   const videoFrameRatio = videoFrame.width / videoFrame.height;
   const backgroundImageRatio = backgroundImage.width / backgroundImage.height;
-  if (backgroundImageRatio > videoFrameRatio) {
+  if (backgroundImageRatio < videoFrameRatio) {
     const newHeight = videoFrame.height * (backgroundImage.width / videoFrame.width);
     y = Math.round((height - newHeight) / 2);
     height = Math.round(newHeight);
-  } else if (backgroundImageRatio < videoFrameRatio) {
+  } else if (backgroundImageRatio > videoFrameRatio) {
     const newWidth = videoFrame.width * (backgroundImage.height / videoFrame.height);
     x = Math.round((width - newWidth) / 2);
     width = Math.round(newWidth);

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -13,7 +13,7 @@ interface VirtualBackgroundProcessorOptions {
    *
    * 省略された場合には、元々の背景が使用されます
    */
-  backgroundImage?: CanvasImageSourceWebCodecs;
+  backgroundImage?: HTMLImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | OffscreenCanvas;
 
   /**
    * 背景ぼかし効果の半径（pixel）

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -354,9 +354,9 @@ class TrackProcessor {
     //       "destination-over"にしている。
     this.canvasCtx.globalCompositeOperation = "destination-over";
     if (this.options.backgroundImage !== undefined) {
-      const crop = this.options.backgroundImageRegion || cropBackgroundImageCenter;
+      const decideRegion = this.options.backgroundImageRegion || cropBackgroundImageCenter;
 
-      const region = crop(this.canvas, this.options.backgroundImage);
+      const region = decideRegion(this.canvas, this.options.backgroundImage);
       this.canvasCtx.drawImage(
         this.options.backgroundImage,
         region.x,


### PR DESCRIPTION
今までは、処理対象映像と背景画像のアスペクト比が異なる場合には、背景画像を引き伸ばしていた。
（引き伸ばされたくない場合には、利用側で事前に画像サイズを調整しておく必要がある）

ただし、この辺りの挙動をより柔軟に制御できた方が便利なので、この PR では `VirtualBackgroundProcessorOptions.backgroundImageRegion` というオプションを追加し、利用者がどの領域を使用するかを選択可能にする。

組み込みでは、これまでと同様の挙動となる `fillBackgroundImage`、および、アスペクト比を維持したまま中央部分をクロップする `cropBackgroundImageCenter` を提供している（デフォルトは後者）。