### PR TITLE
仮想背景処理の Safari 対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,6 +2773,15 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3211,6 +3220,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "rollup": "^2.77.2",
         "rollup-plugin-copy": "^3.4.0",
+        "stackblur-canvas": "^2.5.0",
         "typedoc": "^0.23.10",
         "typescript": "^4.7.4"
       }
@@ -3437,6 +3447,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "rollup": "^2.77.2",
         "rollup-plugin-copy": "^3.4.0",
+        "stackblur-canvas": "^2.5.0",
         "typedoc": "^0.23.10",
         "typescript": "^4.7.4"
       }
@@ -5253,6 +5264,12 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
       "dev": true
     },
     "string-width": {

--- a/packages/virtual-background/package.json
+++ b/packages/virtual-background/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "rollup": "^2.77.2",
     "rollup-plugin-copy": "^3.4.0",
+    "stackblur-canvas": "^2.5.0",
     "typedoc": "^0.23.10",
     "typescript": "^4.7.4"
   }

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -220,8 +220,8 @@ class VirtualBackgroundProcessor {
 abstract class TrackProcessor {
   protected options: VirtualBackgroundProcessorOptions;
   protected track: MediaStreamVideoTrack;
-  protected canvas: OffscreenCanvas;
-  protected canvasCtx: OffscreenCanvasRenderingContext2D;
+  protected canvas: OffscreenCanvas | HTMLCanvasElement;
+  protected canvasCtx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
   protected segmentation: SelfieSegmentation;
 
   constructor(
@@ -238,7 +238,13 @@ abstract class TrackProcessor {
     if (width === undefined || height === undefined) {
       throw Error(`Could not retrieve the resolution of the video track: {track}`);
     }
-    this.canvas = new OffscreenCanvas(width, height);
+    if (typeof OffscreenCanvas === "undefined") {
+      this.canvas = document.createElement("canvas");
+      this.canvas.width = width;
+      this.canvas.height = height;
+    } else {
+      this.canvas = new OffscreenCanvas(width, height);
+    }
     const canvasCtx = this.canvas.getContext("2d", { desynchronized: true });
     if (!canvasCtx) {
       throw Error("Failed to get the 2D context of an OffscreenCanvas");

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -327,6 +327,7 @@ abstract class TrackProcessor {
     }
 
     if (this.options.blurRadius !== undefined && this.canvas !== tmpCanvas) {
+      // @ts-ignore
       StackBlur.canvasRGB(tmpCanvas, 0, 0, this.canvas.width, this.canvas.height, this.options.blurRadius);
       this.canvasCtx.drawImage(tmpCanvas, 0, 0, this.canvas.width, this.canvas.height);
     }

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -153,8 +153,13 @@ class VirtualBackgroundProcessor {
       throw Error("Virtual background processing has already started.");
     }
 
-    // TODO:
-    this.trackProcessor = new TrackProcessorWithBreakoutBox(track, this.segmentation, options);
+    if (TrackProcessorWithBreakoutBox.isSupported()) {
+      this.trackProcessor = new TrackProcessorWithBreakoutBox(track, this.segmentation, options);
+    } else if (TrackProcessorWithRequestVideoFrameCallback.isSupported()) {
+      this.trackProcessor = new TrackProcessorWithRequestVideoFrameCallback(track, this.segmentation, options);
+    } else {
+      throw Error("Unsupported browser");
+    }
     this.originalTrack = track;
     this.processedTrack = await this.trackProcessor.startProcessing();
     return this.processedTrack;

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -3,6 +3,7 @@ import {
   SelfieSegmentationConfig,
   Results as SelfieSegmentationResults,
 } from "@mediapipe/selfie_segmentation";
+import * as StackBlur from "stackblur-canvas";
 
 /**
  * {@link VirtualBackgroundProcessor.startProcessing} メソッドに指定可能なオプション
@@ -275,7 +276,11 @@ abstract class TrackProcessor {
     this.canvasCtx.drawImage(segmentationResults.image, 0, 0, this.canvas.width, this.canvas.height);
 
     if (this.options.blurRadius !== undefined) {
-      this.canvasCtx.filter = `blur(${this.options.blurRadius}px)`;
+      // this.canvasCtx.filter = `blur(${this.options.blurRadius}px)`;
+      //this.canvasCtx.filter = `blur(${this.options.blurRadius}px)`;
+
+      // @ts-ignore
+      StackBlur.canvasRGBA(this.canvas, 0, 0, this.canvas.width, this.canvas.height, this.options.blurRadius);
     }
 
     // NOTE: mediapipeの例 (https://google.github.io/mediapipe/solutions/selfie_segmentation.html) では、


### PR DESCRIPTION
Safari の安定版で映像フレームを効率的に処理するための `requestVideoFrameCallbackHandle` メソッドが使用可能になったので、それを用いた仮想背景処理に対応する。