### PR TITLE
仮想背景有効時に発生する iPhone での権限エラーを修正

### DIFF
--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -452,6 +452,8 @@ class TrackProcessorWithRequestVideoFrameCallback extends TrackProcessor {
     // requestVideoFrameCallbackHandle()` はトラックではなくビデオ単位のメソッドなので
     // 内部的に HTMLVideoElement を生成する
     this.video = document.createElement("video");
+    this.video.muted = true;
+    this.video.playsInline = true;
     this.video.srcObject = new MediaStream([track]);
 
     // 処理後の映像フレームを書き込むための canvas を生成する


### PR DESCRIPTION
仮想背景処理を行う際、Safari 向けには内部的に HTMLVideoElement を生成しているが iPhone で動かすと、その play() メソッド呼び出し時に権限エラーが出ていたので修正する。
仮想背景処理には不要な権限（e.g., 音声再生）を HTMLVideoElement から外すことで iPhone でも動作可能となった。