### PR TITLE
仮想背景処理中での入力映像トラックの解像度変更に対応

### DIFF
--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -334,6 +334,20 @@ abstract class TrackProcessor {
 
     this.canvasCtx.restore();
   }
+
+  protected updateCanvasSizeIfNeed(width: number, height: number): boolean {
+    const changed = this.canvas.width !== width || this.canvas.height !== height;
+    if (changed) {
+      this.canvas.width = width;
+      this.canvas.height = height;
+
+      if (this.blurCanvas !== undefined) {
+        this.blurCanvas.width = width;
+        this.blurCanvas.height = height;
+      }
+    }
+    return changed;
+  }
 }
 
 class TrackProcessorWithBreakoutBox extends TrackProcessor {
@@ -401,6 +415,8 @@ class TrackProcessorWithBreakoutBox extends TrackProcessor {
   }
 
   private async transform(frame: VideoFrame, controller: TransformStreamDefaultController<VideoFrame>): Promise<void> {
+    this.updateCanvasSizeIfNeed(frame.displayWidth, frame.displayHeight);
+
     const timestamp = frame.timestamp;
     const duration = frame.duration;
     const image = await createImageBitmap(frame);
@@ -499,6 +515,16 @@ class TrackProcessorWithRequestVideoFrameCallback extends TrackProcessor {
   }
 
   private async onFrame() {
+    const width = this.track.getSettings().width;
+    const height = this.track.getSettings().height;
+
+    if (width !== undefined && height !== undefined) {
+      if (this.updateCanvasSizeIfNeed(width, height)) {
+        this.processedCanvas.width = this.canvas.width;
+        this.processedCanvas.height = this.canvas.height;
+      }
+    }
+
     this.canvasCtx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     this.canvasCtx.drawImage(this.video, 0, 0, this.canvas.width, this.canvas.height);
     let imageData = this.canvasCtx.getImageData(0, 0, this.canvas.width, this.canvas.height);


### PR DESCRIPTION
iPhone では実際の入力映像が流れるまでは、映像トラックは `getUserMedia` で指定した値を解像度として返す。
ただし、この値は入力映像が流れ始めると更新されることがあり、その場合に `VirtualBackgroundProcessor` を通すと出力映像のアスペクト比がずれるなどの問題が発生していた。
この PR では、仮想背景処理中の解像度変更に対応することでこの問題に対処する。