### PR TITLE
明るさ調整の際に基準とする領域を指定可能にする

### DIFF
--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -7,7 +7,8 @@
     <h1>Media Processors: 明るさ調整サンプル</h1>
 
     <h3>入力映像設定</h3>
-    解像度: <input id="videoWidth" type="text" value="320">x<input id="videoHeight" type="text" value="320"><br />
+    <!-- TODO: 更新可能にする or 固定値にする -->
+    解像度: <input id="videoWidth" type="text" value="480">x<input id="videoHeight" type="text" value="480"><br />
     FPS: <input id="videoFps" type="text" value="30">
 
     <h3>明るさ調整設定</h3>
@@ -26,6 +27,8 @@
     EntropyThreshold: <input id="entropyThreshold" type="range" min="0" max="0.2" value="0.05" step="0.01"
                              oninput="updateOption('entropyThreshold')">
                       <span id="entropyThreshold-value">0.5</span><br />
+    SelfieSegmentation: <input id="selfieSegmentation" type='checkbox'
+                               oninput="updateOption('selfieSegmentation')" /><br />
     <br />
 
     <h3>左: 処理映像、右: オリジナル映像</h3>
@@ -58,10 +61,21 @@
       }
 
       function updateOption(name) {
-          const value = Number(document.getElementById(name).value);
-          document.getElementById(`${name}-value`).innerText = value;
           var options = {};
-          options[name] = value;
+
+          if (name == 'selfieSegmentation') {
+              const checked = document.getElementById(name).checked;
+              if (checked) {
+                  options['mask'] = new Shiguredo.SelfieSegmentationMask("./light-adjustment/");
+              } else {
+                  options['mask'] = new Shiguredo.AllMask();
+              }
+          }  else {
+              const value = Number(document.getElementById(name).value);
+              document.getElementById(`${name}-value`).innerText = value;
+              options[name] = value;
+          }
+
           processor.setOptions(options);
       }
 

--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -27,8 +27,11 @@
     EntropyThreshold: <input id="entropyThreshold" type="range" min="0" max="0.2" value="0.05" step="0.01"
                              oninput="updateOption('entropyThreshold')">
                       <span id="entropyThreshold-value">0.5</span><br />
-    SelfieSegmentation: <input id="selfieSegmentation" type='checkbox'
-                               oninput="updateOption('selfieSegmentation')" /><br />
+    Focus: <select id="focusMask" size="3" oninput="updateOption('focusMask')">
+              <option value="uniform" selected>Uniform</option>
+              <option value="center">Center</option>
+              <option value="selfieSegmentation">SelfieSegmentation</option>
+           </select>
     <br />
 
     <h3>左: 処理映像、右: オリジナル映像</h3>
@@ -63,12 +66,17 @@
       function updateOption(name) {
           var options = {};
 
-          if (name == 'selfieSegmentation') {
-              const checked = document.getElementById(name).checked;
-              if (checked) {
-                  options['focusMask'] = new Shiguredo.SelfieSegmentationFocusMask("./light-adjustment/");
-              } else {
-                  options['focusMask'] = new Shiguredo.UniformFocusMask();
+          if (name == 'focusMask') {
+              switch (document.getElementById(name).value) {
+              case "uniform":
+                  options[name] = new Shiguredo.UniformFocusMask();
+                  break;
+              case "center":
+                  options[name] = new Shiguredo.CenterFocusMask();
+                  break;
+              case "selfieSegmentation":
+                  options[name] = new Shiguredo.SelfieSegmentationFocusMask("./light-adjustment/");
+                  break;
               }
           }  else {
               const value = Number(document.getElementById(name).value);

--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -66,9 +66,9 @@
           if (name == 'selfieSegmentation') {
               const checked = document.getElementById(name).checked;
               if (checked) {
-                  options['mask'] = new Shiguredo.SelfieSegmentationFocusMask("./light-adjustment/");
+                  options['focusMask'] = new Shiguredo.SelfieSegmentationFocusMask("./light-adjustment/");
               } else {
-                  options['mask'] = new Shiguredo.UniformFocusMask();
+                  options['focusMask'] = new Shiguredo.UniformFocusMask();
               }
           }  else {
               const value = Number(document.getElementById(name).value);

--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -65,38 +65,22 @@
           processor.setOptions(options);
       }
 
-      function showOriginalVideo() {
-          processor.stopProcessing();
+      getUserMedia().then((stream) => {
+          document.getElementById('videoOriginal').srcObject = stream;
 
-          const videoElement = document.getElementById('videoOriginal');
-          getUserMedia().then((stream) => {
-              videoElement.srcObject = stream;
+          const track = stream.getVideoTracks()[0];
+
+          let options = {
+              alpha: Number(document.getElementById('alpha').value),
+              fusion: Number(document.getElementById('fusion').value),
+              minIntensity: Number(document.getElementById('minIntensity').value),
+              maxIntensity: Number(document.getElementById('maxIntensity').value),
+              entropyThreshold: Number(document.getElementById('entropyThreshold').value),
+          };
+          processor.startProcessing(track, options).then((processed_track) => {
+              document.getElementById('videoProcessed').srcObject = new MediaStream([processed_track]);
           });
-      }
-
-
-      function showProcessedVideo() {
-          processor.stopProcessing();
-
-          const videoElement = document.getElementById('videoProcessed');
-          getUserMedia().then((stream) => {
-              const track = stream.getVideoTracks()[0];
-
-              let options = {
-                  alpha: Number(document.getElementById('alpha').value),
-                  fusion: Number(document.getElementById('fusion').value),
-                  minIntensity: Number(document.getElementById('minIntensity').value),
-                  maxIntensity: Number(document.getElementById('maxIntensity').value),
-                  entropyThreshold: Number(document.getElementById('entropyThreshold').value),
-              };
-              processor.startProcessing(track, options).then((processed_track) => {
-                  videoElement.srcObject = new MediaStream([processed_track]);
-              });
-          });
-      }
-
-      showOriginalVideo();
-      showProcessedVideo();
+      });
     </script>
   </body>
 </html>

--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -66,9 +66,9 @@
           if (name == 'selfieSegmentation') {
               const checked = document.getElementById(name).checked;
               if (checked) {
-                  options['mask'] = new Shiguredo.SelfieSegmentationMask("./light-adjustment/");
+                  options['mask'] = new Shiguredo.SelfieSegmentationFocusMask("./light-adjustment/");
               } else {
-                  options['mask'] = new Shiguredo.AllMask();
+                  options['mask'] = new Shiguredo.UniformFocusMask();
               }
           }  else {
               const value = Number(document.getElementById(name).value);

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -33,12 +33,12 @@ class CenterFocusMask implements FocusMask {
       this.mask = new Uint8Array(width * height);
       this.mask.fill(0);
 
-      const y_start = Math.floor(height / 3);
-      const y_end = y_start * 2;
-      let x_start = y_start * width + Math.floor(width / 3);
-      let x_end = y_start * width + Math.floor(width / 3) * 2;
-      for (let y = y_start; y < y_end; y++, x_start += width, x_end += width) {
-        this.mask.fill(255, x_start, x_end);
+      const yStart = Math.floor(height / 3);
+      const yEnd = yStart * 2;
+      let xStart = yStart * width + Math.floor(width / 3);
+      let xEnd = yStart * width + Math.floor(width / 3) * 2;
+      for (let y = yStart; y < yEnd; y++, xStart += width, xEnd += width) {
+        this.mask.fill(255, xStart, xEnd);
       }
     }
     return Promise.resolve(this.mask);

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -136,7 +136,7 @@ class Agcwd {
     const isStateObsolete = this.wasm.exports.agcwdIsStateObsolete as CallableFunction;
     if (this.isStateObsolete || (isStateObsolete(this.agcwdPtr, this.imagePtr) as boolean)) {
       // TODO: handle mask
-      (this.wasm.exports.agcwdUpdateState as CallableFunction)(this.agcwdPtr, this.imagePtr, this.imagePtr);
+      (this.wasm.exports.agcwdUpdateState as CallableFunction)(this.agcwdPtr, this.imagePtr, 0);
       this.isStateObsolete = false;
       this.stats.totalUpdateStateCount += 1;
     }

--- a/packages/light-adjustment/zig/src/main.zig
+++ b/packages/light-adjustment/zig/src/main.zig
@@ -62,7 +62,6 @@ pub const AgcwdOptions = struct {
     min_intensity: u8 = 10,
     max_intensity: u8 = 245,
     entropy_threshold: f32 = 0.05,
-    mask_ratio_threshold: f32 = 0.05, // TODO: remove(?)
 };
 
 /// 画像の明るさ調整処理を行うための構造体
@@ -100,11 +99,7 @@ pub const Agcwd = struct {
         var pdf = Pdf.fromImage(image);
         self.entropy = pdf.entropy();
 
-        if (self.options.mask_ratio_threshold < mask.getMaskRatio()) {
-            // マスク領域が十分に大きい場合には、マスク領域だけを使って PDF を計算する
-            pdf = Pdf.fromImageAndMask(image, mask);
-        }
-
+        pdf = Pdf.fromImageAndMask(image, mask);
         const cdf = Cdf.fromPdf(&pdf.toWeightingDistribution(self.options.alpha));
         self.mapping_curve = cdf.toIntensityMappingCurve(self.options);
     }

--- a/packages/light-adjustment/zig/src/main.zig
+++ b/packages/light-adjustment/zig/src/main.zig
@@ -133,7 +133,7 @@ const Pdf = struct {
         {
             var i: usize = 0;
             while (i < image.data.len) : (i += 4) {
-                const weight = if (mask) |non_null_mask| non_null_mask.data[i] else 255;
+                const weight = if (mask) |non_null_mask| non_null_mask.data[i / 4] else 255;
                 histogram[image.getRgb(i).intensity()] += weight;
                 total += weight;
             }

--- a/packages/light-adjustment/zig/src/main.zig
+++ b/packages/light-adjustment/zig/src/main.zig
@@ -135,7 +135,7 @@ const Pdf = struct {
             while (i < image.data.len) : (i += 4) {
                 const weight = if (mask) |non_null_mask| non_null_mask.data[i] else 255;
                 histogram[image.getRgb(i).intensity()] += weight;
-                total += 255;
+                total += weight;
             }
         }
 

--- a/packages/light-adjustment/zig/src/main.zig
+++ b/packages/light-adjustment/zig/src/main.zig
@@ -140,10 +140,12 @@ const Pdf = struct {
         }
 
         var table: [256]f32 = undefined;
-        const n = @intToFloat(f32, total);
+        if (total > 0) {
+            const n = @intToFloat(f32, total);
 
-        for (histogram, 0..) |weight, i| {
-            table[i] = @intToFloat(f32, weight) / n;
+            for (histogram, 0..) |weight, i| {
+                table[i] = @intToFloat(f32, weight) / n;
+            }
         }
 
         return .{ .table = table };


### PR DESCRIPTION
現時点では以下の三つを組み込みで提供:
- 画像の全領域を均等に扱う
- 画像を九分割して、その中央部分を基準とする
- @mediapipe/selfie-segmentation で人物領域を取り出して、そこを基準とする