### PR TITLE
映像トラックから解像度を取得できなくてもエラーにしない

### DIFF
--- a/examples/video-multi-processors.html
+++ b/examples/video-multi-processors.html
@@ -1,0 +1,42 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Media Processors: ライト調整 + 仮想背景</title>
+  </head>
+  <body>
+    <h1>Media Processors: ライト調整 + 仮想背景</h1>
+
+    <h2>左: 処理後の映像、右: オリジナル映像</h2>    
+    <video id="processedVideo" muted autoplay playsinline></video>
+    <video id="originalVideo" muted autoplay playsinline></video>
+
+    <script src="./light-adjustment/light_adjustment.js"></script>
+    <script src="./virtual-background/virtual_background.js"></script>
+    <script>
+      if (!Shiguredo.VirtualBackgroundProcessor.isSupported() || !Shiguredo.LightAdjustmentProcessor.isSupported()) {
+        alert("Unsupported platform");
+        throw Error("Unsupported platform");
+      }
+
+      function getUserMedia() {
+        const constraints = {
+          width: 320,
+          height: 240,
+        };
+        return navigator.mediaDevices.getUserMedia({video: constraints});
+      }
+
+      getUserMedia().then(async (stream) => {
+        const lightAdjustmentProcessor = new Shiguredo.LightAdjustmentProcessor();
+        const virtualBackgroundProcessor = new Shiguredo.VirtualBackgroundProcessor("./virtual-background/");
+
+        const originalTrack = stream.getVideoTracks()[0];
+        const processedTrack0 = await lightAdjustmentProcessor.startProcessing(originalTrack);
+        const processedTrack1 = await virtualBackgroundProcessor.startProcessing(processedTrack0, {blurRadius: 5});
+
+        document.getElementById("originalVideo").srcObject = new MediaStream([originalTrack]);
+        document.getElementById("processedVideo").srcObject = new MediaStream([processedTrack1]);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -325,10 +325,8 @@ class WasmLightAdjustment {
     this.wasm = wasm;
     this.memory = wasm.exports.memory as WebAssembly.Memory;
 
-    const { width, height } = track.getSettings();
-    if (width === undefined || height === undefined) {
-      throw new Error("Failed to get video track resolution");
-    }
+    const width = track.getSettings().width || 0;
+    const height = track.getSettings().height || 0;
     this.imageWidth = width;
     this.imageHeight = height;
 

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -171,8 +171,8 @@ class RequestVideoFrameCallbackProcessor extends Processor {
   private requestVideoFrameCallbackHandle?: number;
 
   // 処理結果画像を書き込むキャンバス
-  private canvas: OffscreenCanvas;
-  private canvasCtx: OffscreenCanvasRenderingContext2D;
+  private canvas: HTMLCanvasElement;
+  private canvasCtx: CanvasRenderingContext2D;
 
   // 処理途中の作業用キャンバス
   private tmpCanvas: OffscreenCanvas;
@@ -189,15 +189,19 @@ class RequestVideoFrameCallbackProcessor extends Processor {
     this.video.srcObject = new MediaStream([track]);
 
     // 処理後の映像フレームを書き込むための canvas を生成する
+    // captureStream() を使いたいので OffscreenCanvas にはできない
     const width = track.getSettings().width || 0;
     const height = track.getSettings().height || 0;
-    this.canvas = createOffscreenCanvas(width, height) as OffscreenCanvas;
+    this.canvas = document.createElement("canvas");
+    this.canvas.width = width;
+    this.canvas.height = height;
     const canvasCtx = this.canvas.getContext("2d");
     if (canvasCtx === null) {
       throw Error("Failed to create 2D canvas context");
     }
     this.canvasCtx = canvasCtx;
 
+    // 作業用キャンバスを生成する
     this.tmpCanvas = createOffscreenCanvas(width, height) as OffscreenCanvas;
     const tmpCanvasCtx = this.tmpCanvas.getContext("2d");
     if (tmpCanvasCtx === null) {

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -97,10 +97,8 @@ class BreakoutBoxProcessor extends Processor {
     this.processor = new MediaStreamTrackProcessor({ track: this.track });
 
     // 作業用キャンバスを作成
-    const { width, height } = track.getSettings();
-    if (width === undefined || height === undefined) {
-      throw Error(`Could not retrieve the resolution of the video track: {track}`);
-    }
+    const width = track.getSettings().width || 0;
+    const height = track.getSettings().height || 0;
 
     this.canvas = new OffscreenCanvas(width, height);
     const canvasCtx = this.canvas.getContext("2d", { desynchronized: true, willReadFrequently: true });
@@ -187,11 +185,8 @@ class RequestVideoFrameCallbackProcessor extends Processor {
     // 処理後の映像フレームを書き込むための canvas を生成する
     //
     // captureStream() メソッドは OffscreenCanvas にはないようなので HTMLCanvasElement を使用する
-    const width = track.getSettings().width;
-    const height = track.getSettings().height;
-    if (width === undefined || height === undefined) {
-      throw Error(`Could not retrieve the resolution of the video track: {track}`);
-    }
+    const width = track.getSettings().width || 0;
+    const height = track.getSettings().height || 0;
     this.canvas = document.createElement("canvas");
     this.canvas.width = width;
     this.canvas.height = height;

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -177,7 +177,7 @@ class RequestVideoFrameCallbackProcessor extends Processor {
   // 処理途中の作業用キャンバス
   private tmpCanvas: HTMLCanvasElement;
   private tmpCanvasCtx: CanvasRenderingContext2D;
-  
+
   constructor(track: MediaStreamVideoTrack, callback: ProcessImageDataCallback) {
     super(track, callback);
 

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -326,6 +326,7 @@ function trimLastSlash(s: string): string {
   return s;
 }
 
+// TODO(sile): Safari 16.4 から OffscreenCanvas に対応したので、そのうちにこの関数は削除する
 function createOffscreenCanvas(width: number, height: number): OffscreenCanvas | HTMLCanvasElement {
   if (typeof OffscreenCanvas === "undefined") {
     // OffscreenCanvas が使えない場合には通常の canvas で代替する

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -153,9 +153,9 @@ class VirtualBackgroundProcessor {
     track: MediaStreamVideoTrack,
     options: VirtualBackgroundProcessorOptions = {}
   ): Promise<MediaStreamVideoTrack> {
-    const width = track.getSettings().width || 0;
-    const height = track.getSettings().height || 0;
-    const canvas = createOffscreenCanvas(width, height);
+    const initialWidth = track.getSettings().width || 0;
+    const initialHeight = track.getSettings().height || 0;    
+    const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,
       willReadFrequently: true,
@@ -169,7 +169,7 @@ class VirtualBackgroundProcessor {
     // TODO(sile): Safari が filter に対応したらこの分岐は削除する
     let blurCanvasCtx: OffscreenCanvasRenderingContext2D | undefined;
     if (options.blurRadius !== undefined && browser() === "safari") {
-      const ctx = createOffscreenCanvas(width, height).getContext("2d", {
+      const ctx = createOffscreenCanvas(initialWidth, initialHeight).getContext("2d", {
         desynchronized: true,
         willReadFrequently: true,
       });
@@ -187,6 +187,7 @@ class VirtualBackgroundProcessor {
     }
     this.segmentation.setOptions({ modelSelection });
     this.segmentation.onResults((results) => {
+      const {width, height} = results.segmentationMask;
       resizeCanvasIfNeed(width, height, canvas);
       if (blurCanvasCtx !== undefined) {
         resizeCanvasIfNeed(width, height, blurCanvasCtx.canvas);

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -154,7 +154,7 @@ class VirtualBackgroundProcessor {
     options: VirtualBackgroundProcessorOptions = {}
   ): Promise<MediaStreamVideoTrack> {
     const initialWidth = track.getSettings().width || 0;
-    const initialHeight = track.getSettings().height || 0;    
+    const initialHeight = track.getSettings().height || 0;
     const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,
@@ -187,7 +187,7 @@ class VirtualBackgroundProcessor {
     }
     this.segmentation.setOptions({ modelSelection });
     this.segmentation.onResults((results) => {
-      const {width, height} = results.segmentationMask;
+      const { width, height } = results.segmentationMask;
       resizeCanvasIfNeed(width, height, canvas);
       if (blurCanvasCtx !== undefined) {
         resizeCanvasIfNeed(width, height, blurCanvasCtx.canvas);

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -153,11 +153,8 @@ class VirtualBackgroundProcessor {
     track: MediaStreamVideoTrack,
     options: VirtualBackgroundProcessorOptions = {}
   ): Promise<MediaStreamVideoTrack> {
-    const width = track.getSettings().width;
-    const height = track.getSettings().height;
-    if (width === undefined || height === undefined) {
-      throw Error(`Could not retrieve the resolution of the video track: {track}`);
-    }
+    const width = track.getSettings().width || 0;
+    const height = track.getSettings().height || 0;
     const canvas = createOffscreenCanvas(width, height);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,


### PR DESCRIPTION
例えば LightAdjustmentProcessor の結果を VirtualBackgroundProcessor に渡す場合には、前者の処理結果の映像トラックでは `track.getSettings()` の `width` と `height` の値が `undefined` になる。
今まではこのケースはエラーにしていたが、映像トラックから解像度が取得できなくても、各フレームを処理する段階では解像度が判明し処理を行うことが可能なので、このケースでもエラーにせずに空解像度 (0x0) 扱いにする。
これによって複数映像プロセッサを組み合わせて使うことが可能となる。
ただし Safari の場合には別の理由（`HTMLCanvasElement.captureStream()` を `srcObject` に設定した `HTMLVideoElement` を `canavs.drawImage()` で書き込むと何故か canvas が更新されないままになる）で複数プロセッサを組み合わせることは現時点ではできない。