### PR TITLE
CPU-GPUの転送を減らして背景ぼかし処理を高速化

### DIFF
--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -152,10 +152,14 @@ class LightAdjustmentProcessor {
     this.updateOptions(options);
 
     this.resetStats();
-    return this.trackProcessor.startProcessing({track, imageDataCallback: async (image: ImageData) => {
-      await this.processImage(image);
-      return image;
-    }, canvasCallback: undefined});
+    return this.trackProcessor.startProcessing({
+      track,
+      imageDataCallback: async (image: ImageData) => {
+        await this.processImage(image);
+        return image;
+      },
+      canvasCallback: undefined,
+    });
   }
 
   private async processImage(image: ImageData): Promise<void> {

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -152,10 +152,10 @@ class LightAdjustmentProcessor {
     this.updateOptions(options);
 
     this.resetStats();
-    return this.trackProcessor.startProcessing(track, async (image: ImageData) => {
+    return this.trackProcessor.startProcessing({track, imageDataCallback: async (image: ImageData) => {
       await this.processImage(image);
       return image;
-    });
+    }, canvasCallback: undefined});
   }
 
   private async processImage(image: ImageData): Promise<void> {

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -196,15 +196,11 @@ class VirtualBackgroundProcessor {
     });
 
     // 仮想背景処理を開始
-    return this.trackProcessor.startProcessing({
-      track,
-      canvasCallback: async (image: ImageBitmap | HTMLVideoElement) => {
-        // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
-        await this.segmentation.send({ image });
+    return this.trackProcessor.startProcessing(track, async (image: ImageBitmap | HTMLVideoElement) => {
+      // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
+      await this.segmentation.send({ image });
 
-        return canvas;
-      },
-      imageDataCallback: undefined,
+      return canvas;
     });
   }
 

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -196,12 +196,16 @@ class VirtualBackgroundProcessor {
     });
 
     // 仮想背景処理を開始
-    return this.trackProcessor.startProcessing({track, canvasCallback: async (image: ImageBitmap | HTMLVideoElement) => {
-      // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
-      await this.segmentation.send({ image });
+    return this.trackProcessor.startProcessing({
+      track,
+      canvasCallback: async (image: ImageBitmap | HTMLVideoElement) => {
+        // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
+        await this.segmentation.send({ image });
 
-      return canvas;
-    }, imageDataCallback: undefined});
+        return canvas;
+      },
+      imageDataCallback: undefined,
+    });
   }
 
   /**

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -158,7 +158,7 @@ class VirtualBackgroundProcessor {
     const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,
-      willReadFrequently: true,
+      willReadFrequently: false,
     }) as OffscreenCanvasRenderingContext2D | null;
     if (canvasCtx === null) {
       throw Error("Failed to create 2D canvas context");
@@ -196,14 +196,12 @@ class VirtualBackgroundProcessor {
     });
 
     // 仮想背景処理を開始
-    return this.trackProcessor.startProcessing(track, async (image: ImageData) => {
-      const { width, height } = image;
-
+    return this.trackProcessor.startProcessing({track, canvasCallback: async (image: ImageBitmap | HTMLVideoElement) => {
       // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
       await this.segmentation.send({ image });
 
-      return canvasCtx.getImageData(0, 0, width, height);
-    });
+      return canvas;
+    }, imageDataCallback: undefined});
   }
 
   /**

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -158,7 +158,7 @@ class VirtualBackgroundProcessor {
     const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,
-      willReadFrequently: false,
+      willReadFrequently: false, // ここをtrueにするとCPU-GPUメモリ転送が発生して遅くなる
     }) as OffscreenCanvasRenderingContext2D | null;
     if (canvasCtx === null) {
       throw Error("Failed to create 2D canvas context");


### PR DESCRIPTION
#345 の対応

OffscreenCanvasからImageDataを作る処理などでおそらくCPU-GPU間のメモリ転送処理が入り、パフォーマンスが低下していたため、処理を変更して高速化する。

callbackへ渡すデータの型とcallbackが返すデータの型を両方とも変更している。

1920x1080 30fpsの場合で下記のように十分高速化できた。
<img width="1615" alt="image" src="https://github.com/shiguredo/media-processors/assets/6997928/7ab05242-784f-47af-b3bf-f4ade598329c">
