### PR TITLE
VideoTrackProcessorに平均処理時間・フレームレート計算機能を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
     - @kounoike
 - [FIX] Zig の `@truncate` やキャスト関連に破壊的変更があったため対応
     - @kounoike
+- [ADD] VideoTrackProcessor に平均処理時間・フレームレートを計算する機能を追加
+    - @kounoike
 
 ## virtual-background-2023.2.0
 

--- a/examples/light-adjustment.html
+++ b/examples/light-adjustment.html
@@ -42,10 +42,10 @@
                       <span id="entropyThreshold-value">0.5</span><br />
     -->
     <br />
+    <br />
 
+    フレーム処理時間: <span id="elapsed">0.0</span> 秒 フレームレート: <span id="fps">0.0</span>FPS<br />
     <h3>左: 処理映像、右: オリジナル映像</h3>
-
-    フレーム処理時間: <span id="elapsed">0.0</span> 秒<br />
     <video id="videoProcessed" autoplay playsinline></video>
     <video id="videoOriginal" autoplay playsinline></video><br />
 
@@ -58,10 +58,10 @@
 
       const processor = new Shiguredo.LightAdjustmentProcessor();
       setInterval(() => {
-          const stats = processor.getStats();
-          const elapsed = stats.getAverageProcessedTimeMs() / 1000;
+          const elapsed = processor.getAverageProcessedTimeMs() / 1000;
           document.getElementById('elapsed').innerText = elapsed.toFixed(4).padStart(4, '0');
-          processor.resetStats();
+          const fps = processor.getFps();
+          document.getElementById('fps').innerText = fps.toFixed(2).padStart(5, '0');
       }, 300);
 
       function getUserMedia() {

--- a/examples/video-multi-processors.html
+++ b/examples/video-multi-processors.html
@@ -7,6 +7,8 @@
     <h1>Media Processors: ライト調整 + 仮想背景</h1>
 
     <h2>左: 処理後の映像、右: オリジナル映像</h2>    
+    ライト調整: フレーム処理時間: <span id="elapsed0">0.0</span> 秒 フレームレート: <span id="fps0">0.0</span>FPS<br />
+    仮想背景: フレーム処理時間: <span id="elapsed1">0.0</span> 秒 フレームレート: <span id="fps1">0.0</span>FPS<br />
     <video id="processedVideo" muted autoplay playsinline></video>
     <video id="originalVideo" muted autoplay playsinline></video>
 
@@ -17,6 +19,18 @@
         alert("Unsupported platform");
         throw Error("Unsupported platform");
       }
+      const lightAdjustmentProcessor = new Shiguredo.LightAdjustmentProcessor();
+      const virtualBackgroundProcessor = new Shiguredo.VirtualBackgroundProcessor("./virtual-background/");
+      setInterval(() => {
+          const elapsed0 = lightAdjustmentProcessor.getAverageProcessedTimeMs() / 1000;
+          document.getElementById('elapsed0').innerText = elapsed0.toFixed(4).padStart(4, '0');
+          const fps0 = lightAdjustmentProcessor.getFps();
+          document.getElementById('fps0').innerText = fps0.toFixed(2).padStart(5, '0');
+          const elapsed1 = virtualBackgroundProcessor.getAverageProcessedTimeMs() / 1000;
+          document.getElementById('elapsed1').innerText = elapsed1.toFixed(4).padStart(4, '0');
+          const fps1 = virtualBackgroundProcessor.getFps();
+          document.getElementById('fps1').innerText = fps1.toFixed(2).padStart(5, '0');
+      }, 300);
 
       function getUserMedia() {
         const constraints = {
@@ -27,8 +41,6 @@
       }
 
       getUserMedia().then(async (stream) => {
-        const lightAdjustmentProcessor = new Shiguredo.LightAdjustmentProcessor();
-        const virtualBackgroundProcessor = new Shiguredo.VirtualBackgroundProcessor("./virtual-background/");
 
         const originalTrack = stream.getVideoTracks()[0];
         const processedTrack0 = await lightAdjustmentProcessor.startProcessing(originalTrack);

--- a/examples/virtual-background.html
+++ b/examples/virtual-background.html
@@ -21,7 +21,9 @@
 
     <input type="button" value="仮想背景ON" onClick="showProcessedVideo()">
     <input type="button" value="仮想背景OFF" onClick="showOriginalVideo()">
-    <br /><br />
+    <br />
+    フレーム処理時間: <span id="elapsed">0.0</span> 秒 フレームレート: <span id="fps">0.0</span>FPS<br />
+    <br />
 
     <video id="video" autoplay playsinline></video>
 
@@ -34,6 +36,12 @@
 
       const assetsPath = "./virtual-background/";
       const processor = new Shiguredo.VirtualBackgroundProcessor(assetsPath);
+      setInterval(() => {
+          const elapsed = processor.getAverageProcessedTimeMs() / 1000;
+          document.getElementById('elapsed').innerText = elapsed.toFixed(4).padStart(4, '0');
+          const fps = processor.getFps();
+          document.getElementById('fps').innerText = fps.toFixed(2).padStart(5, '0');
+      }, 300);
 
       function getUserMedia() {
           const constraints = {

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -284,6 +284,20 @@ class LightAdjustmentProcessor {
   resetStats(): void {
     this.stats.reset();
   }
+
+  /**
+   * VideoTrackProcessorで計算したFPSを取得します
+   */
+  getFps(): number {
+    return this.trackProcessor.getFps();
+  }
+
+  /**
+   * VideoTrackProcessorで計算した平均処理時間を取得します
+   */
+  getAverageProcessedTimeMs(): number {
+    return this.trackProcessor.getAverageProcessedTimeMs();
+  }
 }
 
 /**

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -81,8 +81,8 @@ abstract class Processor {
 
   // 統計機能
   private numFramesToRecord = 100;
-  private startTimes: number[] = new Array(this.numFramesToRecord).fill(0);
-  private processTimes: number[] = new Array(this.numFramesToRecord).fill(0);
+  private startTimes: number[] = new Array(this.numFramesToRecord).fill(0) as number[];
+  private processTimes: number[] = new Array(this.numFramesToRecord).fill(0) as number[];
   private count = 0;
   private currentFps = 0;
   private currentSumProcessedTimeMs = 0;
@@ -99,7 +99,7 @@ abstract class Processor {
     const idx = this.count % this.numFramesToRecord;
     this.currentFps = this.numFramesToRecord / ((now - this.startTimes[idx]) / 1000);
     this.startTimes[idx] = now;
-  };
+  }
 
   recordStopFrame() {
     const now = performance.now();
@@ -110,7 +110,7 @@ abstract class Processor {
     this.currentSumProcessedTimeMs = this.currentSumProcessedTimeMs - prevTime + processTime;
     this.processTimes[this.count % this.numFramesToRecord] = processTime;
     this.count++;
-  };
+  }
 }
 
 class BreakoutBoxProcessor extends Processor {

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -252,6 +252,28 @@ class VirtualBackgroundProcessor {
     return this.trackProcessor.getProcessedTrack();
   }
 
+  /**
+   * 平均フレームレートを返します
+   *
+   * 処理開始直後は実際の値と異なる値が返されます
+   *
+   * @returns 平均フレームレート
+   */
+  getFps(): number {
+    return this.trackProcessor.getFps();
+  }
+
+  /**
+   * フレームの平均処理時間を返します
+   *
+   * 処理開始直後は実際の値と異なる値が返されます
+   *
+   * @returns 平均処理時間 (ミリ秒)
+   */
+  getAverageProcessedTimeMs(): number {
+    return this.trackProcessor.getAverageProcessedTimeMs();
+  }
+
   private updateOffscreenCanvas(
     segmentationResults: SelfieSegmentationResults,
     canvasCtx: OffscreenCanvasRenderingContext2D,


### PR DESCRIPTION
https://github.com/shiguredo/media-processors/issues/346#issuecomment-1604573705

VideoTrackProcessorで共通して平均処理時間・フレームレートを計算する。

LightAdjustmentの統計機能はexamplesでの表示は置き換えたが、他の詳細も取得している＆互換性がなくなるので残しておく。