### PR TITLE
ライト調整のwasmビルド＆tsのミスを修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [FIX] Zig の WebAssembly ビルドで addSharedLibrary から addBinary を使うよう変更になったので対応
+  - https://ziglang.org/documentation/master/#Freestanding
+  - https://github.com/ziglang/zig/pull/17815
+  - @kounoike
 - [FIX] zig で std.mem.copy ではなく @memcpy を使うようにする
   - https://github.com/ziglang/zig/pull/18143
   - @voluntas

--- a/packages/light-adjustment/build-wasm.sh
+++ b/packages/light-adjustment/build-wasm.sh
@@ -7,4 +7,4 @@ zig build -Doptimize=ReleaseFast -Dtarget=wasm32-freestanding
 cd ..
 
 mkdir -p dist/
-cp zig/zig-out/lib/light_adjustment.wasm dist/
+cp zig/zig-out/bin/light_adjustment.wasm dist/

--- a/packages/light-adjustment/src/light_adjustment.ts
+++ b/packages/light-adjustment/src/light_adjustment.ts
@@ -599,7 +599,7 @@ class SelfieSegmentationFocusMask implements FocusMask {
     const config: SelfieSegmentationConfig = {}
     const trimmedAssetsPath = trimLastSlash(assetsPath)
     config.locateFile = (file: string) => {
-      return `${trimLastSlash}/${file}`
+      return `${trimmedAssetsPath}/${file}`
     }
     this.segmentation = new SelfieSegmentation(config)
 

--- a/packages/light-adjustment/zig/build.zig
+++ b/packages/light-adjustment/zig/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
     // wasm をビルドするためには addExecutable() を使う必要がある
     // 以前は addSharedLibrary() だったが2024/01/04現在の master では変更されている
     // https://ziglang.org/documentation/master/#Freestanding
-    var lib = b.addExecutable(.{
+    var wasm = b.addExecutable(.{
         .name = "light_adjustment",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
@@ -30,13 +30,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    lib.rdynamic = true;
-    lib.entry = .disabled;
+    wasm.rdynamic = true;
+    wasm.entry = .disabled;
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
-    b.installArtifact(lib);
+    b.installArtifact(wasm);
 
     // Creates a step for unit testing.
     const main_tests = b.addTest(.{

--- a/packages/light-adjustment/zig/build.zig
+++ b/packages/light-adjustment/zig/build.zig
@@ -19,8 +19,10 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    // wasm をビルドするためには addStaticLibrary() ではなく addSharedLibrary() を使う必要がある
-    var lib = b.addSharedLibrary(.{
+    // wasm をビルドするためには addExecutable() を使う必要がある
+    // 以前は addSharedLibrary() だったが2024/01/04現在の master では変更されている
+    // https://ziglang.org/documentation/master/#Freestanding
+    var lib = b.addExecutable(.{
         .name = "light_adjustment",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
@@ -29,6 +31,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     lib.rdynamic = true;
+    lib.entry = .disabled;
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when


### PR DESCRIPTION
fix #425

https://zenn.dev/izreit/articles/1f0a3f090f24f4 によると https://ziglang.org/documentation/master/#Freestanding が変更されているので、それに従えば良いらしい

ついでにtsの方でアセットパス組み立てにおかしなところがあったので修正して、再びライト調整が動作するようにしました