### PR TITLE
音声のみの MP4 をロードした後に `Mp4MediaStream.play()` を呼び出すとエラーになる問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [Fix] 音声のみの MP4 をロードした後に `Mp4MediaStream.play()` を呼び出すとエラーになる問題を修正する
+  - @sile
+
 ## mp4-media-stream-2024.1.0
 
 **初リリース**

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -206,8 +206,8 @@ class Mp4MediaStream {
       if (!(await VideoDecoder.isConfigSupported(config)).supported) {
         throw new Error(`Unsupported video decoder configuration: ${JSON.stringify(config)}`)
       }
-      this.info = info
     }
+    this.info = info
 
     return { audio: info.audioConfigs.length > 0, video: info.videoConfigs.length > 0 }
   }


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request includes a fix for an error that occurs when calling `Mp4MediaStream.play()` after loading an audio-only MP4 file, along with a minor code adjustment in the `Mp4MediaStream` class.

Bug Fix:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added a note about fixing the issue where calling `Mp4MediaStream.play()` after loading an audio-only MP4 file results in an error.

Code Adjustment:

* [`packages/mp4-media-stream/src/mp4_media_stream.ts`](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL209-R210): Moved the assignment of `this.info` to ensure it is set after checking the video decoder configuration.