### PR TITLE
`Mp4MediaStream` が生成した `MediaStream` を WebRTC で配信すると、受信側で映像と音声のタイムスタンプが大幅にズレる問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,16 @@
 
 ## develop
 
+- [CHANGE] `Mp4MediaStream.play()` を非同期にする
+  - @sile
+- [FIX] `Mp4MediaStream` が生成した `MediaStream` を WebRTC の入力とすると受信側で映像と音声のタイムスタンプが大幅にズレることがある問題を修正する
+  - 以前は `MediaStreamTrackGenerator` を使って、映像および音声の出力先の `MediaTrack` を生成していた
+    - ただし `MediaStreamTrackGenerator` に映像フレーム・音声データを書き込む際に指定するタイムスタンプを 0 始まりにすると、WebRTC を通した場合に映像と音声でのタイムスタンプが大幅（e.g., 数時間以上）にズレる問題が確認された
+    - 実際に `MediaStreamTrackProcessor` が生成したタイムスタンプを確認したところ、0 始まりではなかったが、このタイムスタンプの基準値を外部から取得する簡単な方法はなさそうだった
+      - 一度 `getUserMedia()` を呼び出してその結果を `MediaStreamTrackProcessor` に渡すことで取得できないことはないが現実的ではない
+  - そのため、`MediaStreamTrackGenerator` は使うのは止めて、映像では `HTMLCanvasElement` を、音声では `AudioContext` を使って `MediaTrack` を生成するように変更した
+  - @sile
+
 ## mp4-media-stream-2024.1.2
 
 - [FIX] 音声のみの MP4 をロードした後に `Mp4MediaStream.play()` を呼び出すとエラーになる問題を修正する

--- a/examples/mp4-media-stream/main.mts
+++ b/examples/mp4-media-stream/main.mts
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  function play() {
+  async function play() {
     if (mp4MediaStream === undefined) {
       alert('MP4 ファイルが未選択です')
       return
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const options = {
       repeat: document.getElementById('repeat').checked,
     }
-    const stream = mp4MediaStream.play(options)
+    const stream = await mp4MediaStream.play(options)
 
     const output = document.getElementById('output')
     output.srcObject = stream

--- a/packages/mp4-media-stream/rollup.config.mjs
+++ b/packages/mp4-media-stream/rollup.config.mjs
@@ -22,6 +22,10 @@ export default [
         __WASM__: () => fs.readFileSync("../../target/wasm32-unknown-unknown/release/mp4_media_stream.wasm", "base64"),
         preventAssignment: true
       }),
+      replace({
+        __AUDIO_PROCESSOR__: () => fs.readFileSync("src/audio_processor.js"),
+        preventAssignment: true
+      }),
       typescript({module: "esnext"}),
       commonjs(),
       resolve()
@@ -40,6 +44,10 @@ export default [
     plugins: [
       replace({
         __WASM__: () => fs.readFileSync("../../target/wasm32-unknown-unknown/release/mp4_media_stream.wasm", "base64"),
+        preventAssignment: true
+      }),
+      replace({
+        __AUDIO_PROCESSOR__: () => fs.readFileSync("src/audio_processor.js"),
         preventAssignment: true
       }),
       typescript({module: "esnext"}),

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -1,3 +1,4 @@
+// WebCodecs の音声デコーダーが生成した AudioData の中身を MediaTrack に伝えるためのプロセッサー
 class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
   constructor() {
     super()

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -17,7 +17,7 @@ class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
       } else {
         outputChannel[i] = audioData[this.offset]
         this.offset++
-        if (this.offset == audioData.length) {
+        if (this.offset === audioData.length) {
           this.inputBuffer.shift()
           this.offset = 0
         }

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -4,6 +4,7 @@ class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
     this.inputBuffer = []
     this.offset = 0
     this.port.onmessage = (e) => {
+      // TODO: timestamp handling
       this.inputBuffer.push(e.data)
     }
   }

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -10,7 +10,6 @@ class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
   }
 
   process(inputs, outputs, parameters) {
-    const outputChannel = outputs[0][0]
     for (let sampleIdx = 0; sampleIdx < outputs[0][0].length; sampleIdx++) {
       for (let channelIdx = 0; channelIdx < outputs[0].length; channelIdx++) {
         const outputChannel = outputs[0][channelIdx]
@@ -20,16 +19,11 @@ class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
         } else {
           outputChannel[sampleIdx] = audioData.samples[this.offset]
           this.offset++
+          if (this.offset === this.inputBuffer[0].samples.length) {
+            this.inputBuffer.shift()
+            this.offset = 0
+          }
         }
-      }
-
-      if (this.inputBuffer[0] === undefined) {
-        continue
-      }
-
-      if (this.offset === this.inputBuffer[0].samples.length) {
-        this.inputBuffer.shift()
-        this.offset = 0
       }
     }
     return true

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -1,0 +1,30 @@
+class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this.inputBuffer = []
+    this.offset = 0
+    this.port.onmessage = (e) => {
+      this.inputBuffer.push(e.data)
+    }
+  }
+
+  process(inputs, outputs, parameters) {
+    const outputChannel = outputs[0][0]
+    for (let i = 0; i < outputChannel.length; i++) {
+      const audioData = this.inputBuffer[0]
+      if (audioData === undefined) {
+        outputChannel[i] = 0
+      } else {
+        outputChannel[i] = audioData[this.offset]
+        this.offset++
+        if (this.offset == audioData.length) {
+          this.inputBuffer.shift()
+          this.offset = 0
+        }
+      }
+    }
+    return true
+  }
+}
+
+registerProcessor('mp4-media-stream-audio-worklet-processor', Mp4MediaStreamAudioWorkletProcessor)

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -242,7 +242,7 @@ class Mp4MediaStream {
 
     const init = {
       output: async (frame: VideoFrame) => {
-        if (player.canvas == undefined || player.canvasCtx === undefined) {
+        if (player.canvas === undefined || player.canvasCtx === undefined) {
           return
         }
 

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -50,7 +50,6 @@ class Mp4MediaStream {
    */
   static isSupported(): boolean {
     return !(
-      typeof MediaStreamTrackGenerator === 'undefined' ||
       typeof AudioDecoder === 'undefined' ||
       typeof VideoDecoder === 'undefined'
     )

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -1,5 +1,6 @@
 const WASM_BASE64 = '__WASM__'
 
+// biome-ignore lint/style/noUnusedTemplateLiteral: audio_processor.js 内で文字列を使えるように `...` で囲む
 const AUDIO_WORKLET_PROCESSOR_CODE = `__AUDIO_PROCESSOR__`
 const AUDIO_WORKLET_PROCESSOR_NAME = 'mp4-media-stream-audio-worklet-processor'
 

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -526,6 +526,7 @@ class Player {
     await this.closeVideoDecoder()
 
     if (this.audioContext !== undefined) {
+      await this.audioContext.close()
       this.audioContext = undefined
       this.audioInputNode = undefined
     }

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -299,6 +299,7 @@ class Mp4MediaStream {
 
           const samples = new Float32Array(data.numberOfFrames * data.numberOfChannels)
           data.copyTo(samples, { planeIndex: 0 })
+          data.close()
 
           const timestamp = data.timestamp
           player.audioInputNode.port.postMessage({ timestamp, samples }, [samples.buffer])

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -449,13 +449,14 @@ class Player {
       const blob = new Blob([AUDIO_WORKLET_PROCESSOR_CODE], { type: 'application/javascript' })
       this.audioContext = new AudioContext({ sampleRate: OPUS_SAMPLE_RATE })
       await this.audioContext.audioWorklet.addModule(URL.createObjectURL(blob))
-      console.log('create audio node')
       const audioInputNode = new AudioWorkletNode(this.audioContext, AUDIO_WORKLET_PROCESSOR_NAME)
-      audioInputNode.connect(this.audioContext.destination)
       // audioInputNode.port.postMessage(data, [data.buffer]);
 
+      const destination = this.audioContext.createMediaStreamDestination()
+      audioInputNode.connect(destination)
+
       const generator = new MediaStreamTrackGenerator({ kind: 'audio' })
-      tracks.push(generator)
+      tracks.push(destination.stream.getAudioTracks()[0])
       this.audioWriter = generator.writable.getWriter()
     }
     if (this.video) {

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -40,7 +40,6 @@ class Mp4MediaStream {
    * 実行環境が必要な機能をサポートしているかどうかを判定します
    *
    * 以下のクラスが利用可能である必要があります:
-   * - MediaStreamTrackGenerator
    * - AudioDecoder
    * - VideoDecoder
    *
@@ -287,7 +286,7 @@ class Mp4MediaStream {
     const config = this.wasmJsonToValue(configWasmJson) as AudioDecoderConfig
     const init = {
       output: async (data: AudioData) => {
-        if (player.audioContext === undefined || player.audioInputNode === undefined) {
+        if (player.audioInputNode === undefined) {
           return
         }
 
@@ -449,14 +448,9 @@ class Player {
       this.audioContext = new AudioContext({ sampleRate: this.sampleRate })
       await this.audioContext.audioWorklet.addModule(URL.createObjectURL(blob))
 
-      const workletOptions = {
+      this.audioInputNode = new AudioWorkletNode(this.audioContext, AUDIO_WORKLET_PROCESSOR_NAME, {
         outputChannelCount: [this.numberOfChannels],
-      }
-      this.audioInputNode = new AudioWorkletNode(
-        this.audioContext,
-        AUDIO_WORKLET_PROCESSOR_NAME,
-        workletOptions,
-      )
+      })
 
       const destination = this.audioContext.createMediaStreamDestination()
       this.audioInputNode.connect(destination)


### PR DESCRIPTION
Copilot Summary
------------------

This pull request makes significant changes to the `Mp4MediaStream` class to improve its functionality and fix existing issues. The most important changes include making the `play` method asynchronous, replacing the use of `MediaStreamTrackGenerator` with `HTMLCanvasElement` and `AudioContext`, and adding a new audio processor.

### Improvements to `Mp4MediaStream`:

* Made `Mp4MediaStream.play()` asynchronous to allow for better handling of media streams. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R23) [[2]](diffhunk://#diff-d685fe362fc13b8d2d799c7e6ec0223fa3bebf86ba885f629252c746b0db72a0L31-R31) [[3]](diffhunk://#diff-d685fe362fc13b8d2d799c7e6ec0223fa3bebf86ba885f629252c746b0db72a0L40-R40)
* Replaced `MediaStreamTrackGenerator` with `HTMLCanvasElement` for video and `AudioContext` for audio to generate `MediaTrack`, addressing the issue of desynchronized timestamps in WebRTC. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R23) [[2]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL39-R49) [[3]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL144-R143) [[4]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL153-R152) [[5]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL245-R254) [[6]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL299-R306) [[7]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faR424-R466) [[8]](diffhunk://#diff-bcf77a6797ccae8ba7f1a797aac5d161794ea3bd310a4a80acc28a04cb38d9faL515-R532)

### Addition of Audio Processor:

* Introduced `Mp4MediaStreamAudioWorkletProcessor` to handle audio data generated by WebCodecs and pass it to the `MediaTrack`.
* Updated the rollup configuration to include the new audio processor. [[1]](diffhunk://#diff-a6430d9421dee3d140ab961afdd04112485137ea9a312a59adf37a23c3b520d3R25-R28) [[2]](diffhunk://#diff-a6430d9421dee3d140ab961afdd04112485137ea9a312a59adf37a23c3b520d3R49-R52)

### Documentation and Support Updates:

* Updated `CHANGES.md` to reflect the new asynchronous `play` method and the fix for timestamp desynchronization.
* Modified the `isSupported` method to remove the check for `MediaStreamTrackGenerator` since it is no longer used.