### PR TITLE
`Mp4MediaStream` の対応コーデックに AV1 を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] `Mp4MediaStream` の対応コーデックに AV1 を追加する
+  - @sile
 - [ADD] `Mp4MediaStream` の対応コーデックに VP9 を追加する
   - @sile
 - [ADD] `Mp4MediaStream` の対応コーデックに VP8 を追加する

--- a/packages/mp4-media-stream/README.md
+++ b/packages/mp4-media-stream/README.md
@@ -34,6 +34,7 @@ video.srcObject = stream
   - H.264
   - VP8
   - VP9
+  - AV1
 - 音声:
   - AAC
   - Opus

--- a/packages/mp4-media-stream/wasm/src/player.rs
+++ b/packages/mp4-media-stream/wasm/src/player.rs
@@ -188,6 +188,10 @@ impl TrackPlayer {
                 let config = VideoDecoderConfig::from_vp09_box(b);
                 WasmApi::create_video_decoder(self.player_id, config).await
             }
+            SampleEntry::Av01(b) => {
+                let config = VideoDecoderConfig::from_av01_box(b);
+                WasmApi::create_video_decoder(self.player_id, config).await
+            }
             SampleEntry::Opus(b) => {
                 let config = AudioDecoderConfig::from_opus_box(b);
                 WasmApi::create_audio_decoder(self.player_id, config).await


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request adds support for the AV1 codec to the `Mp4MediaStream` package. The most important changes include updating documentation, modifying the `mp4.rs` file to handle the AV1 codec, and updating the `TrackPlayer` implementation to support AV1.

### Documentation Updates:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R15): Added AV1 to the list of supported codecs for `Mp4MediaStream`.
* [`packages/mp4-media-stream/README.md`](diffhunk://#diff-fa6016604dd54f20e1cb5d274f534173e784749c6a9e2aa0fb49477d648501e6R37): Updated the list of supported codecs to include AV1.

### Code Updates:
* `packages/mp4-media-stream/wasm/src/mp4.rs`: 
  * Imported `Av01Box` to handle AV1 codec.
  * Added `from_av01_box` method in `VideoDecoderConfig` to parse AV1 box information.
  * Updated `Track` and `Mp4` implementations to recognize and process `Av01` sample entries. [[1]](diffhunk://#diff-f6e0ce0ec6e53048be6864662d189d0664a5b362a3d6cc39228f19e974b3af09R168) [[2]](diffhunk://#diff-f6e0ce0ec6e53048be6864662d189d0664a5b362a3d6cc39228f19e974b3af09R265-R267)

* `packages/mp4-media-stream/wasm/src/player.rs`: 
  * Added support for AV1 in the `TrackPlayer` implementation.