### PR TITLE
`Mp4MediaStream` の対応コーデックに H.265 を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] `Mp4MediaStream` の対応コーデックに H.265 を追加する
+  - @sile
 - [ADD] `Mp4MediaStream` の対応コーデックに AV1 を追加する
   - @sile
 - [ADD] `Mp4MediaStream` の対応コーデックに VP9 を追加する

--- a/packages/mp4-media-stream/README.md
+++ b/packages/mp4-media-stream/README.md
@@ -32,6 +32,7 @@ video.srcObject = stream
 
 - 映像:
   - H.264
+  - H.265
   - VP8
   - VP9
   - AV1

--- a/packages/mp4-media-stream/wasm/src/player.rs
+++ b/packages/mp4-media-stream/wasm/src/player.rs
@@ -180,6 +180,10 @@ impl TrackPlayer {
                 let config = VideoDecoderConfig::from_avc1_box(b);
                 WasmApi::create_video_decoder(self.player_id, config).await
             }
+            SampleEntry::Hev1(b) => {
+                let config = VideoDecoderConfig::from_hev1_box(b);
+                WasmApi::create_video_decoder(self.player_id, config).await
+            }
             SampleEntry::Vp08(b) => {
                 let config = VideoDecoderConfig::from_vp08_box(b);
                 WasmApi::create_video_decoder(self.player_id, config).await


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request mainly adds support for the H.265 codec to the `Mp4MediaStream` package. The most important changes include updates to the documentation, the addition of new methods and handling for the H.265 codec, and corresponding updates to codec handling in various parts of the codebase.

### Documentation Updates:
* Added H.265 to the list of supported codecs in `CHANGES.md` and `README.md`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R15) [[2]](diffhunk://#diff-fa6016604dd54f20e1cb5d274f534173e784749c6a9e2aa0fb49477d648501e6R35)

### Codebase Updates:
* Added `Hev1Box` to the list of imported boxes in `mp4.rs`.
* Implemented `from_hev1_box` method to handle H.265 codec configuration in `mp4.rs`.
* Updated `Track` and `Mp4` implementations to recognize and process `Hev1Box` entries. [[1]](diffhunk://#diff-f6e0ce0ec6e53048be6864662d189d0664a5b362a3d6cc39228f19e974b3af09R215) [[2]](diffhunk://#diff-f6e0ce0ec6e53048be6864662d189d0664a5b362a3d6cc39228f19e974b3af09R309-R311)
* Updated `TrackPlayer` implementation to handle `Hev1Box` entries and create video decoders accordingly in `player.rs`.