### PR TITLE
vite + oxfmt + oxlint を vite-plus (vp) に統一する

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,4 +1,3 @@
 {
-  "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "ignorePatterns": ["dist/**"],
 }

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -1,5 +1,4 @@
 {
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "oxc", "unicorn", "import", "promise", "react", "vitest"],
   "categories": {
     // 明らかに間違っているコード
@@ -79,6 +78,9 @@
     "no-useless-call": "error",
     // 不要な文字列連結を禁止
     "no-useless-concat": "error",
+
+    // import 文のソート（宣言順は無視、メンバー名のみソート）
+    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
 
     // ===== eslint: モダン構文の推奨 =====
     // Math.pow() より ** 演算子を推奨
@@ -481,8 +483,8 @@
     "unicorn/no-zero-fractions": "error",
 
     // ===== unicorn: 数値リテラル =====
-    // 数値リテラルの大文字小文字を統一
-    "unicorn/number-literal-case": "error",
+    // 数値リテラルの大文字小文字（oxfmt が小文字化するため無効化）
+    "unicorn/number-literal-case": "off",
     // 数値区切りのスタイルを統一
     "unicorn/numeric-separators-style": "error",
 
@@ -767,6 +769,166 @@
         "typescript/no-unsafe-member-access": "off",
         "typescript/no-unsafe-return": "off",
         "typescript/no-unsafe-type-assertion": "off",
+      },
+    },
+    {
+      // vite 設定ファイルは Node.js モジュールの使用を許可
+      "files": ["**/vite.config.*"],
+      "rules": {
+        "import/exports-last": "off",
+        "import/no-nodejs-modules": "off",
+        "no-ternary": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off",
+      },
+    },
+    {
+      // 型宣言ファイルは import/export の制約を緩和
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "id-length": "off",
+        "import/group-exports": "off",
+        "import/no-named-export": "off",
+        "import/unambiguous": "off",
+        "max-params": "off",
+      },
+    },
+    {
+      // examples は型安全性とスタイルを緩和
+      "files": ["examples/**/*.ts"],
+      "rules": {
+        "func-style": "off",
+        "id-length": "off",
+        "init-declarations": "off",
+        "max-lines-per-function": "off",
+        "no-alert": "off",
+        "no-magic-numbers": "off",
+        "no-shadow": "off",
+        "no-void": "off",
+        "prefer-destructuring": "off",
+        "require-await": "off",
+        "import/no-named-export": "off",
+        "promise/always-return": "off",
+        "promise/no-nesting": "off",
+        "promise/prefer-await-to-then": "off",
+        "typescript/explicit-function-return-type": "off",
+        "typescript/no-misused-promises": "off",
+        "typescript/no-non-null-assertion": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/require-await": "off",
+        "typescript/strict-boolean-expressions": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "unicorn/no-array-for-each": "off",
+        "unicorn/numeric-separators-style": "off",
+        "unicorn/prefer-global-this": "off",
+        "unicorn/prefer-query-selector": "off",
+        "vitest/require-hook": "off",
+      },
+    },
+    {
+      // JavaScript ファイルは型安全性を緩和
+      "files": ["**/*.js"],
+      "rules": {
+        "id-length": "off",
+        "no-magic-numbers": "off",
+        "prefer-destructuring": "off",
+        "import/unambiguous": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "unicorn/filename-case": "off",
+        "unicorn/prefer-add-event-listener": "off",
+        "vitest/require-hook": "off",
+      },
+    },
+    {
+      // ライブラリソースファイルはメディア処理特有のパターンを許可
+      "files": ["packages/*/src/**/*.ts"],
+      "rules": {
+        // メディア処理では数値リテラルが頻出（ピクセル値、バッファサイズ等）
+        "no-magic-numbers": "off",
+        // 短い変数名（i, x, y 等）はメディア処理で一般的
+        "id-length": "off",
+        // ファイル名は既存の snake_case を維持（変更すると公開 API の破壊的変更になる）
+        "unicorn/filename-case": "off",
+        // 関数宣言も許可
+        "func-style": "off",
+        // メディア処理関数は長くなりがち
+        "max-lines-per-function": "off",
+        // ファイル行数制限
+        "max-lines": "off",
+        // 複数クラスを同一ファイルに許可
+        "max-classes-per-file": "off",
+        // パラメータ数の制限を緩和
+        "max-params": "off",
+        // インラインコメントを許可
+        "no-inline-comments": "off",
+        // TODO コメントを許可
+        "no-warning-comments": "off",
+        // void 演算子を許可（Promise の明示的な無視）
+        "no-void": "off",
+        // 変数の宣言時初期化を必須としない
+        "init-declarations": "off",
+        // 否定条件を許可
+        "no-negated-condition": "off",
+        // 名前付きエクスポートを許可（ライブラリの公開 API）
+        "import/no-named-export": "off",
+        // namespace インポートを許可
+        "import/no-namespace": "off",
+        // default export の推奨を無効化
+        "import/prefer-default-export": "off",
+        // Promise のネストを許可（ストリーム処理等）
+        "promise/no-nesting": "off",
+        // コールバックパターンを許可（Web API との連携）
+        "promise/prefer-await-to-callbacks": "off",
+        // then パターンを許可
+        "promise/prefer-await-to-then": "off",
+        // globalThis より window を許可（ブラウザ API）
+        "unicorn/prefer-global-this": "off",
+        // console.warn/error はライブラリの非致命的エラー通知に使用
+        "no-console": "off",
+        // 変数シャドウイング（error 等の一般的な名前）
+        "no-shadow": "off",
+        // ループ内の await は順次処理で必要
+        "no-await-in-loop": "off",
+        // async はインターフェース準拠のために使用
+        "require-await": "off",
+        "typescript/require-await": "off",
+        // 型アサーションはメディア API との連携で必要
+        "typescript/no-unsafe-type-assertion": "off",
+        // Function 型の呼び出し（コールバック等）
+        "typescript/no-unsafe-call": "off",
+        // any 型の代入（外部 API との連携）
+        "typescript/no-unsafe-assignment": "off",
+        // any 型の引数
+        "typescript/no-unsafe-argument": "off",
+        // any 型の返り値
+        "typescript/no-unsafe-return": "off",
+        // catch コールバックの unknown 型
+        "typescript/use-unknown-in-catch-callback-variable": "off",
+        // nullable boolean の条件式
+        "typescript/strict-boolean-expressions": "off",
+        // 非 null アサーション
+        "typescript/no-non-null-assertion": "off",
+        // type と value の重複 import
+        "no-duplicate-imports": "off",
+        // this を使わないメソッド（インターフェース準拠）
+        "class-methods-use-this": "off",
+        // 戻り値型の明示（メディア処理の内部関数は省略を許可）
+        "typescript/explicit-function-return-type": "off",
+        // @ts-expect-error の説明
+        "typescript/ban-ts-comment": "off",
+        // await 式のメンバーアクセス
+        "unicorn/no-await-expression-member": "off",
+        // 三項演算子の推奨
+        "unicorn/prefer-ternary": "off",
       },
     },
   ],

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
 ### misc
 
+- [CHANGE] Vite+ へ移行する
+  - @voluntas
 - [CHANGE] 利用していなかった typedoc を削除する
   - @voluntas
 

--- a/examples/mp4-media-stream/main.ts
+++ b/examples/mp4-media-stream/main.ts
@@ -5,12 +5,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   if (!Mp4MediaStream.isSupported()) {
     alert("Unsupported platform");
-    throw Error("Unsupported platform");
+    throw new Error("Unsupported platform");
   }
 
   async function load() {
-    const input = document.getElementById("input");
-    const files = input.files;
+    const input = document.querySelector("#input");
+    const { files } = input;
     if (files === null || files.length === 0) {
       return;
     }
@@ -22,9 +22,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     try {
       mp4MediaStream = await Mp4MediaStream.load(file);
-    } catch (e) {
-      alert(e.message);
-      throw e;
+    } catch (error) {
+      alert(error.message);
+      throw error;
     }
   }
 
@@ -35,11 +35,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const options = {
-      repeat: document.getElementById("repeat").checked,
+      repeat: document.querySelector("#repeat").checked,
     };
     const stream = await mp4MediaStream.play(options);
 
-    const output = document.getElementById("output");
+    const output = document.querySelector("#output");
     output.srcObject = stream;
   }
 
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     await mp4MediaStream.stop();
   }
 
-  document.getElementById("input").addEventListener("change", load);
-  document.getElementById("play").addEventListener("click", play);
-  document.getElementById("stop").addEventListener("click", stop);
+  document.querySelector("#input").addEventListener("change", load);
+  document.querySelector("#play").addEventListener("click", play);
+  document.querySelector("#stop").addEventListener("click", stop);
 });

--- a/examples/noise-suppression/main.ts
+++ b/examples/noise-suppression/main.ts
@@ -3,7 +3,7 @@ import { NoiseSuppressionProcessor } from "@shiguredo/noise-suppression";
 document.addEventListener("DOMContentLoaded", async () => {
   if (!NoiseSuppressionProcessor.isSupported()) {
     alert("Unsupported platform");
-    throw Error("Unsupported platform");
+    throw new Error("Unsupported platform");
   }
 
   const processor = new NoiseSuppressionProcessor();
@@ -18,25 +18,25 @@ document.addEventListener("DOMContentLoaded", async () => {
       audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
       analyserOriginal = audioCtx.createAnalyser();
-      visualize(analyserOriginal, document.getElementById("oscilloscopeOriginal"));
+      visualize(analyserOriginal, document.querySelector("#oscilloscopeOriginal"));
 
       analyserProcessed = audioCtx.createAnalyser();
-      visualize(analyserProcessed, document.getElementById("oscilloscopeProcessed"));
+      visualize(analyserProcessed, document.querySelector("#oscilloscopeProcessed"));
     }
   }
 
-  function getUserMedia() {
+  async function getUserMedia() {
     const constraints = {
       audio: {
-        sampleRate: { ideal: 48000 },
-        sampleSize: { ideal: 480 },
         channelCount: { exact: 1 },
+        sampleRate: { ideal: 48_000 },
+        sampleSize: { ideal: 480 },
       },
     };
     return navigator.mediaDevices.getUserMedia(constraints).then((stream) => {
       initAudioAnalysersIfNeed();
 
-      if (sourceOriginal != undefined) {
+      if (sourceOriginal !== undefined) {
         sourceOriginal.disconnect();
       }
       sourceOriginal = audioCtx.createMediaStreamSource(stream);
@@ -49,9 +49,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   function playOriginalAudio() {
     processor.stopProcessing();
 
-    const audioElement = document.getElementById("audio");
+    const audioElement = document.querySelector("#audio");
     void getUserMedia().then((stream) => {
-      if (sourceProcessed != undefined) {
+      if (sourceProcessed !== undefined) {
         sourceProcessed.disconnect();
         sourceProcessed = undefined;
       }
@@ -62,13 +62,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   function playProcessedAudio() {
     processor.stopProcessing();
 
-    const audioElement = document.getElementById("audio");
+    const audioElement = document.querySelector("#audio");
     void getUserMedia().then((stream) => {
       const track = stream.getAudioTracks()[0];
       void processor.startProcessing(track).then((processed_track) => {
         const stream = new MediaStream([processed_track]);
 
-        if (sourceProcessed != undefined) {
+        if (sourceProcessed !== undefined) {
           sourceProcessed.disconnect();
         }
         sourceProcessed = audioCtx.createMediaStreamSource(stream);
@@ -80,7 +80,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function stopAudio() {
-    const audioElement = document.getElementById("audio");
+    const audioElement = document.querySelector("#audio");
     audioElement.pause();
 
     if (sourceOriginal !== undefined) {
@@ -107,8 +107,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
 
     let silence = true;
-    for (let i = 0; i < dataArray.length; i++) {
-      if (dataArray[i] !== 128) {
+    for (const sample of dataArray) {
+      if (sample !== 128) {
         silence = false;
         break;
       }
@@ -120,10 +120,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     canvasCtx.lineWidth = 2;
     canvasCtx.strokeStyle = "rgb(0, 0, 0)";
     canvasCtx.beginPath();
-    const sliceWidth = (canvas.width * 1.0) / bufferLength;
+    const sliceWidth = Number(canvas.width) / bufferLength;
     let x = 0;
     for (let i = 0; i < bufferLength; i++) {
-      const v = dataArray[i] / 128.0;
+      const v = dataArray[i] / 128;
       const y = (v * canvas.height) / 2;
 
       if (i === 0) {
@@ -144,10 +144,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
   }
 
-  document.getElementById("playProcessedAudio").addEventListener("click", playProcessedAudio);
-  document.getElementById("playOriginalAudio").addEventListener("click", playOriginalAudio);
-  document.getElementById("stopAudio").addEventListener("click", stopAudio);
+  document.querySelector("#playProcessedAudio").addEventListener("click", playProcessedAudio);
+  document.querySelector("#playOriginalAudio").addEventListener("click", playOriginalAudio);
+  document.querySelector("#stopAudio").addEventListener("click", stopAudio);
 
-  clearCanvas(document.getElementById("oscilloscopeOriginal"));
-  clearCanvas(document.getElementById("oscilloscopeProcessed"));
+  clearCanvas(document.querySelector("#oscilloscopeOriginal"));
+  clearCanvas(document.querySelector("#oscilloscopeProcessed"));
 });

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,9 +1,9 @@
 {
   "name": "media-processors-examples",
   "scripts": {
-    "dev": "vite",
-    "preview": "vite preview",
-    "build": "vite build",
+    "dev": "vp dev",
+    "preview": "vp preview",
+    "build": "vp build",
     "check": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/virtual-background/main.ts
+++ b/examples/virtual-background/main.ts
@@ -4,24 +4,24 @@ import img from "./background.jpg";
 document.addEventListener("DOMContentLoaded", async () => {
   if (!VirtualBackgroundProcessor.isSupported()) {
     alert("Unsupported platform");
-    throw Error("Unsupported platform");
+    throw new Error("Unsupported platform");
   }
 
   const assetsPath = ".";
   const processor = new VirtualBackgroundProcessor(assetsPath);
   setInterval(() => {
     const elapsed = processor.getAverageProcessedTimeMs() / 1000;
-    document.getElementById("elapsed").innerText = elapsed.toFixed(4).padStart(4, "0");
+    document.querySelector("#elapsed").textContent = elapsed.toFixed(4).padStart(4, "0");
     const fps = processor.getFps();
-    document.getElementById("fps").innerText = fps.toFixed(2).padStart(5, "0");
+    document.querySelector("#fps").textContent = fps.toFixed(2).padStart(5, "0");
   }, 300);
 
-  function getUserMedia() {
+  async function getUserMedia() {
     const constraints = {
-      width: document.getElementById("videoWidth").value,
-      height: document.getElementById("videoHeight").value,
-      frameRate: { ideal: document.getElementById("videoFps").value },
-      deviceId: document.getElementById("videoDevice").value,
+      deviceId: document.querySelector("#videoDevice").value,
+      frameRate: { ideal: document.querySelector("#videoFps").value },
+      height: document.querySelector("#videoHeight").value,
+      width: document.querySelector("#videoWidth").value,
     };
     return navigator.mediaDevices.getUserMedia({ video: constraints }).then((result) => {
       updateDeviceList();
@@ -38,12 +38,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     void navigator.mediaDevices.enumerateDevices().then((devices) => {
       const videoDevices = devices.filter((device) => device.kind === "videoinput" && device.label);
-      const select = document.getElementById("videoDevice");
+      const select = document.querySelector("#videoDevice");
       videoDevices.forEach((device) => {
         const option = document.createElement("option");
         option.value = device.deviceId;
         option.text = device.label;
-        select.appendChild(option);
+        select.append(option);
       });
     });
   }
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   function showOriginalVideo() {
     processor.stopProcessing();
 
-    const videoElement = document.getElementById("video");
+    const videoElement = document.querySelector("#video");
     void getUserMedia().then((stream) => {
       videoElement.srcObject = stream;
     });
@@ -60,42 +60,44 @@ document.addEventListener("DOMContentLoaded", async () => {
   function showProcessedVideo() {
     processor.stopProcessing();
 
-    const videoElement = document.getElementById("video");
+    const videoElement = document.querySelector("#video");
     void getUserMedia().then((stream) => {
       const track = stream.getVideoTracks()[0];
 
       let blurRadius: number;
       let backgroundImage: HTMLImageElement;
-      const virtualBackgroundType = document.getElementById(
-        "virtualBackgroundType",
-      ) as HTMLSelectElement;
+      const virtualBackgroundType = document.querySelector("#virtualBackgroundType")!;
       if (virtualBackgroundType === null) {
         return;
       }
       switch (virtualBackgroundType.value) {
-        case "blur-5":
+        case "blur-5": {
           blurRadius = 5;
           break;
-        case "blur-15":
+        }
+        case "blur-15": {
           blurRadius = 15;
           break;
-        case "image":
+        }
+        case "image": {
           backgroundImage = new Image();
           backgroundImage.src = img;
           break;
-        default:
+        }
+        default: {
           return;
+        }
       }
 
-      const options = { blurRadius, backgroundImage };
+      const options = { backgroundImage, blurRadius };
       void processor.startProcessing(track, options).then((processed_track) => {
         videoElement.srcObject = new MediaStream([processed_track]);
       });
     });
   }
 
-  document.getElementById("virtualBackgroundOn")?.addEventListener("click", showProcessedVideo);
-  document.getElementById("virtualBackgroundOff")?.addEventListener("click", showOriginalVideo);
+  document.querySelector("#virtualBackgroundOn")?.addEventListener("click", showProcessedVideo);
+  document.querySelector("#virtualBackgroundOff")?.addEventListener("click", showOriginalVideo);
 
   showOriginalVideo();
 });

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,28 +1,20 @@
+import { defineConfig } from "vite-plus";
+import { resolve } from "node:path";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
-import { resolve } from "node:path";
-import { defineConfig } from "vite";
-
 export default defineConfig({
-  root: resolve(__dirname),
   base: process.env.NODE_ENV === "production" ? "/media-processors/" : "/",
-  resolve: {
-    preserveSymlinks: true,
-    alias: {
-      "@shiguredo/virtual-background": resolve(
-        __dirname,
-        "../packages/virtual-background/dist/virtual_background.js",
-      ),
-      "@shiguredo/noise-suppression": resolve(
-        __dirname,
-        "../packages/noise-suppression/dist/noise_suppression.js",
-      ),
-      "@shiguredo/mp4-media-stream": resolve(
-        __dirname,
-        "../packages/mp4-media-stream/dist/mp4_media_stream.js",
-      ),
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, "index.html"),
+        mp4MediaStream: resolve(__dirname, "mp4-media-stream/index.html"),
+        noiseSuppression: resolve(__dirname, "noise-suppression/index.html"),
+        virtualBackground: resolve(__dirname, "virtual-background/index.html"),
+      },
     },
   },
+  envDir: resolve(__dirname, ".."),
   optimizeDeps: {
     exclude: [
       "@shiguredo/virtual-background",
@@ -30,28 +22,35 @@ export default defineConfig({
       "@shiguredo/mp4-media-stream",
     ],
   },
-  build: {
-    rollupOptions: {
-      input: {
-        index: resolve(__dirname, "index.html"),
-        virtualBackground: resolve(__dirname, "virtual-background/index.html"),
-        noiseSuppression: resolve(__dirname, "noise-suppression/index.html"),
-        mp4MediaStream: resolve(__dirname, "mp4-media-stream/index.html"),
-      },
-    },
-  },
-  envDir: resolve(__dirname, ".."),
   plugins: [
     viteStaticCopy({
       targets: [
         {
+          dest: "virtual-background",
           src: [
             "../packages/virtual-background/dist/*.{tflite,binarypb,wasm}",
             "../packages/virtual-background/dist/*wasm_bin.js",
           ],
-          dest: "virtual-background",
         },
       ],
     }),
   ],
+  resolve: {
+    alias: {
+      "@shiguredo/mp4-media-stream": resolve(
+        __dirname,
+        "../packages/mp4-media-stream/dist/mp4_media_stream.js",
+      ),
+      "@shiguredo/noise-suppression": resolve(
+        __dirname,
+        "../packages/noise-suppression/dist/noise_suppression.js",
+      ),
+      "@shiguredo/virtual-background": resolve(
+        __dirname,
+        "../packages/virtual-background/dist/virtual_background.js",
+      ),
+    },
+    preserveSymlinks: true,
+  },
+  root: resolve(__dirname),
 });

--- a/package.json
+++ b/package.json
@@ -3,24 +3,22 @@
   "license": "Apache-2.0",
   "author": "Shiguredo Inc.",
   "scripts": {
-    "dev": "vite --config examples/vite.config.ts",
+    "dev": "vp dev --config examples/vite.config.ts",
     "build": "pnpm -r --filter=./packages/* build",
-    "fmt": "oxfmt --write .",
-    "lint": "oxlint --type-aware",
-    "lint:fix": "oxlint --type-aware --fix",
+    "fmt": "vp fmt",
+    "lint": "vp lint --type-aware",
+    "lint:fix": "vp lint --type-aware --fix",
     "typecheck": "pnpm -r --filter=./packages/* typecheck"
   },
   "dependencies": {
     "@types/dom-mediacapture-transform": "0.1.11"
   },
   "devDependencies": {
-    "oxfmt": "0.36.0",
-    "oxlint": "1.51.0",
-    "oxlint-tsgolint": "0.15.0",
     "typescript": "5.9.3",
-    "vite": "7.3.1",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.11",
     "vite-plugin-dts": "4.5.4",
-    "vite-plugin-static-copy": "3.2.0"
+    "vite-plugin-static-copy": "3.2.0",
+    "vite-plus": "0.1.11"
   },
   "engines": {
     "node": ">=20",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "typescript": "5.9.3",
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.11",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.1.12",
     "vite-plugin-dts": "4.5.4",
-    "vite-plugin-static-copy": "3.2.0",
-    "vite-plus": "0.1.11"
+    "vite-plugin-static-copy": "3.3.0",
+    "vite-plus": "0.1.12"
   },
   "engines": {
     "node": ">=20",

--- a/packages/mp4-media-stream/package.json
+++ b/packages/mp4-media-stream/package.json
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "build": "cargo build --release --target wasm32-unknown-unknown -p mp4_media_stream && vite build && tsc --emitDeclarationOnly",
+    "build": "cargo build --release --target wasm32-unknown-unknown -p mp4_media_stream && vp build && tsc --emitDeclarationOnly",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/mp4-media-stream/src/audio_processor.js
+++ b/packages/mp4-media-stream/src/audio_processor.js
@@ -20,7 +20,7 @@ class Mp4MediaStreamAudioWorkletProcessor extends AudioWorkletProcessor {
           // 後者の場合には、ここでゼロで埋めた分だけ後で破棄しないと、
           // 映像とのリップシンクがズレていってしまう。
           //
-          // this.inputBuffer の中にはタイムスタンプの情報も含まれているので、
+          // This.inputBuffer の中にはタイムスタンプの情報も含まれているので、
           // それを見て、より正確なゼロ埋めやサンプル破棄を行うことは可能なので、
           // 実際にこういったケースが問題になることがあれば対応を検討すること。
           outputChannel[sampleIdx] = 0;

--- a/packages/mp4-media-stream/src/mp4_media_stream.ts
+++ b/packages/mp4-media-stream/src/mp4_media_stream.ts
@@ -8,15 +8,15 @@ const AUDIO_WORKLET_PROCESSOR_NAME = "mp4-media-stream-audio-worklet-processor";
  */
 interface PlayOptions {
   /**
-   * true が指定されると、MP4 ファイルの終端に達した場合に、先頭に戻って再生が繰り返されます
+   * True が指定されると、MP4 ファイルの終端に達した場合に、先頭に戻って再生が繰り返されます
    *
    * デフォルト値は false
    */
   repeat?: boolean;
 }
 
-const AUDIO_DECODER_ID: number = 0;
-const VIDEO_DECODER_ID: number = 1;
+const AUDIO_DECODER_ID = 0;
+const VIDEO_DECODER_ID = 1;
 
 /**
  * MP4 を入力にとって、それを再生する MediaStream を生成するクラス
@@ -26,7 +26,7 @@ class Mp4MediaStream {
   private memory: WebAssembly.Memory;
   private engine: number;
   private info?: Mp4Info;
-  private players: Map<number, Player> = new Map();
+  private players = new Map<number, Player>();
   private nextPlayerId = 0;
 
   private constructor(wasm: WebAssembly.Instance) {
@@ -64,22 +64,14 @@ class Mp4MediaStream {
     const ref: { stream?: Mp4MediaStream } = { stream: undefined };
     const importObject = {
       env: {
-        now() {
-          return performance.now();
+        closeDecoder(playerId: number, decoderId: number) {
+          if (ref.stream) {
+            void ref.stream.closeDecoder(playerId, decoderId);
+          }
         },
         consoleLog(messageWasmJson: number) {
           if (ref.stream) {
             ref.stream.consoleLog(messageWasmJson);
-          }
-        },
-        sleep(resultTx: number, duration: number) {
-          if (ref.stream) {
-            void ref.stream.sleep(resultTx, duration);
-          }
-        },
-        createVideoDecoder(resultTx: number, playerId: number, configWasmJson: number) {
-          if (ref.stream) {
-            void ref.stream.createVideoDecoder(resultTx, playerId, configWasmJson);
           }
         },
         createAudioDecoder(resultTx: number, playerId: number, configWasmJson: number) {
@@ -87,9 +79,9 @@ class Mp4MediaStream {
             void ref.stream.createAudioDecoder(resultTx, playerId, configWasmJson);
           }
         },
-        closeDecoder(playerId: number, decoderId: number) {
+        createVideoDecoder(resultTx: number, playerId: number, configWasmJson: number) {
           if (ref.stream) {
-            void ref.stream.closeDecoder(playerId, decoderId);
+            void ref.stream.createVideoDecoder(resultTx, playerId, configWasmJson);
           }
         },
         decode(
@@ -103,9 +95,17 @@ class Mp4MediaStream {
             ref.stream.decode(playerId, decoderId, metadataWasmJson, dataOffset, dataLen);
           }
         },
+        now() {
+          return performance.now();
+        },
         onEos(playerId: number) {
           if (ref.stream) {
             void ref.stream.onEos(playerId);
+          }
+        },
+        sleep(resultTx: number, duration: number) {
+          if (ref.stream) {
+            void ref.stream.sleep(resultTx, duration);
           }
         },
       },
@@ -139,7 +139,7 @@ class Mp4MediaStream {
    * ようにしないと、WebRTC の受信側で映像のフレームレートが極端に下がったり、止まったりする現象が確認されています。
    * なお、VideoElement はミュートかつ hidden visibility でも問題ありません。
    */
-  play(options: PlayOptions = {}): Promise<MediaStream> {
+  async play(options: PlayOptions = {}): Promise<MediaStream> {
     if (this.info === undefined) {
       // ここには来ないはず
       throw new Error("bug");
@@ -228,7 +228,7 @@ class Mp4MediaStream {
   private async createVideoDecoder(resultTx: number, playerId: number, configWasmJson: number) {
     const player = this.players.get(playerId);
     if (player === undefined) {
-      // stop() と競合したらここに来る可能性がある
+      // Stop() と競合したらここに来る可能性がある
       // すでに停止済みであり、新規でデコーダーを作成する必要はないので、ここで return する
       return;
     }
@@ -247,6 +247,11 @@ class Mp4MediaStream {
     }
 
     const init = {
+      error: async (error: DOMException) => {
+        // デコードエラーが発生した場合には再生を停止する
+        await this.stopPlayer(playerId);
+        throw error;
+      },
       output: async (frame: VideoFrame) => {
         try {
           if (player.canvas === undefined || player.canvasCtx === undefined) {
@@ -266,11 +271,6 @@ class Mp4MediaStream {
           frame.close();
         }
       },
-      error: async (error: DOMException) => {
-        // デコードエラーが発生した場合には再生を停止する
-        await this.stopPlayer(playerId);
-        throw error;
-      },
     };
 
     player.videoDecoder = new VideoDecoder(init);
@@ -285,7 +285,7 @@ class Mp4MediaStream {
   private async createAudioDecoder(resultTx: number, playerId: number, configWasmJson: number) {
     const player = this.players.get(playerId);
     if (player === undefined) {
-      // stop() と競合したらここに来る可能性がある
+      // Stop() と競合したらここに来る可能性がある
       // すでに停止済みであり、新規でデコーダーを作成する必要はないので、ここで return する
       return;
     }
@@ -295,6 +295,11 @@ class Mp4MediaStream {
 
     const config = this.wasmJsonToValue(configWasmJson) as AudioDecoderConfig;
     const init = {
+      error: async (error: DOMException) => {
+        // デコードエラーが発生した場合には再生を停止する
+        await this.stopPlayer(playerId);
+        throw error;
+      },
       output: async (data: AudioData) => {
         try {
           if (player.audioInputNode === undefined) {
@@ -303,23 +308,18 @@ class Mp4MediaStream {
 
           try {
             const samples = new Float32Array(data.numberOfFrames * data.numberOfChannels);
-            data.copyTo(samples, { planeIndex: 0, format: "f32" });
+            data.copyTo(samples, { format: "f32", planeIndex: 0 });
 
-            const timestamp = data.timestamp;
-            player.audioInputNode.port.postMessage({ timestamp, samples }, [samples.buffer]);
-          } catch (e) {
+            const { timestamp } = data;
+            player.audioInputNode.port.postMessage({ samples, timestamp }, [samples.buffer]);
+          } catch (error) {
             // エラーが発生した場合には再生を停止する
             await this.stopPlayer(playerId);
-            throw e;
+            throw error;
           }
         } finally {
           data.close();
         }
-      },
-      error: async (error: DOMException) => {
-        // デコードエラーが発生した場合には再生を停止する
-        await this.stopPlayer(playerId);
-        throw error;
       },
     };
 
@@ -360,7 +360,7 @@ class Mp4MediaStream {
   ) {
     const player = this.players.get(playerId);
     if (player === undefined) {
-      // stop() 呼び出しと競合した場合にここに来る可能性がある
+      // Stop() 呼び出しと競合した場合にここに来る可能性がある
       // すでに停止済みなので、これ以上デコードを行う必要はない
       return;
     }
@@ -404,7 +404,7 @@ class Mp4MediaStream {
     if (result.Err !== undefined) {
       throw new Error(result.Err.message);
     }
-    return result.Ok as object;
+    return result.Ok!;
   }
 
   private valueToWasmJson(value: object): number {
@@ -421,16 +421,16 @@ class Mp4MediaStream {
   }
 }
 
-type Mp4Info = {
+interface Mp4Info {
   audioConfigs: [AudioDecoderConfig];
   videoConfigs: [VideoDecoderConfig];
-};
+}
 
 class Player {
   private audio: boolean;
   private video: boolean;
   private numberOfChannels = 1;
-  private sampleRate = 48000;
+  private sampleRate = 48_000;
   audioDecoder?: AudioDecoder;
   videoDecoder?: VideoDecoder;
   canvas?: HTMLCanvasElement;
@@ -468,7 +468,7 @@ class Player {
       this.canvas = document.createElement("canvas");
       const canvasCtx = this.canvas.getContext("2d");
       if (canvasCtx === null) {
-        throw Error("Failed to create 2D canvas context");
+        throw new Error("Failed to create 2D canvas context");
       }
       this.canvasCtx = canvasCtx;
       tracks.push(this.canvas.captureStream().getVideoTracks()[0]);
@@ -485,16 +485,16 @@ class Player {
     if (decoder.state !== "closed") {
       try {
         await decoder.flush();
-      } catch (e) {
-        if (e instanceof DOMException && e.name === "AbortError") {
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
           // デコーダーのクローズ処理と競合した場合にはここに来る（単に無視すればいい）
         } else {
-          throw e;
+          throw error;
         }
       }
     }
 
-    // await 前後で状態が変わっている可能性があるのでもう一度チェックする
+    // Await 前後で状態が変わっている可能性があるのでもう一度チェックする
     if (decoder === this.audioDecoder && decoder.state !== "closed") {
       decoder.close();
       this.audioDecoder = undefined;
@@ -510,16 +510,16 @@ class Player {
     if (decoder.state !== "closed") {
       try {
         await decoder.flush();
-      } catch (e) {
-        if (e instanceof DOMException && e.name === "AbortError") {
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
           // デコーダーのクローズ処理と競合した場合にはここに来る（単に無視すればいい）
         } else {
-          throw e;
+          throw error;
         }
       }
     }
 
-    // await 前後で状態が変わっている可能性があるのでもう一度チェックする
+    // Await 前後で状態が変わっている可能性があるのでもう一度チェックする
     if (decoder === this.videoDecoder && decoder.state !== "closed") {
       decoder.close();
       this.videoDecoder = undefined;

--- a/packages/mp4-media-stream/vite.config.mjs
+++ b/packages/mp4-media-stream/vite.config.mjs
@@ -1,7 +1,7 @@
-import fs from "node:fs";
+import { defineConfig } from "vite-plus";
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import fs from "node:fs";
 import pkg from "./package.json";
 
 const banner = `/**
@@ -15,16 +15,15 @@ const banner = `/**
 
 export default defineConfig({
   build: {
-    minify: "esbuild",
-    target: "es2023",
     emptyOutDir: true,
-    manifest: true,
     lib: {
       entry: resolve(__dirname, "src/mp4_media_stream.ts"),
+      fileName: "mp4_media_stream",
       formats: ["es"],
       name: "Shiguredo",
-      fileName: "mp4_media_stream",
     },
+    manifest: true,
+    minify: "esbuild",
     rollupOptions: {
       output: {
         banner: banner,
@@ -33,7 +32,7 @@ export default defineConfig({
         {
           name: "wasm-loader",
           transform(code) {
-            return code.replace(/__WASM__/g, () =>
+            return code.replaceAll("__WASM__", () =>
               fs.readFileSync(
                 "../../target/wasm32-unknown-unknown/release/mp4_media_stream.wasm",
                 "base64",
@@ -44,13 +43,14 @@ export default defineConfig({
         {
           name: "audio-processor-loader",
           transform(code) {
-            return code.replace(/__AUDIO_PROCESSOR__/g, () =>
+            return code.replaceAll("__AUDIO_PROCESSOR__", () =>
               fs.readFileSync("src/audio_processor.js"),
             );
           },
         },
       ],
     },
+    target: "es2023",
   },
   plugins: [
     dts({

--- a/packages/noise-suppression/package.json
+++ b/packages/noise-suppression/package.json
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "build": "vite build"
+    "build": "vp build"
   },
   "devDependencies": {
     "@shiguredo/rnnoise-wasm": "2025.1.5"

--- a/packages/noise-suppression/src/noise_suppression.ts
+++ b/packages/noise-suppression/src/noise_suppression.ts
@@ -91,6 +91,7 @@ class NoiseSuppressionProcessor {
    *
    * @returns 処理適用中の場合は音声トラック、それ以外なら `undefined`
    */
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getOriginalTrack(): MediaStreamAudioTrack | undefined {
     return this.originalTrack;
   }
@@ -105,6 +106,7 @@ class NoiseSuppressionProcessor {
    *
    * @returns 処理適用中の場合は音声トラック、それ以外なら `undefined`
    */
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getProcessedTrack(): MediaStreamAudioTrack | undefined {
     return this.processedTrack;
   }
@@ -137,6 +139,7 @@ class TrackProcessor {
 
   startProcessing(): MediaStreamAudioTrack {
     const { signal } = this.abortController;
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     this.processor.readable
       .pipeThrough(
         new TransformStream({
@@ -146,16 +149,20 @@ class TrackProcessor {
         }),
         { signal },
       )
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
       .pipeTo(this.generator.writable)
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
       .catch((error) => {
         if (signal.aborted) {
           console.debug("Shutting down streams after abort.");
         } else {
           console.warn("Error from stream transform:", error);
         }
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
         this.processor.readable.cancel(error).catch((error) => {
           console.warn("Failed to cancel `MediaStreamTrackProcessor`:", error);
         });
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
         this.generator.writable.abort(error).catch((error) => {
           console.warn("Failed to abort `MediaStreamTrackGenerator`:", error);
         });
@@ -217,6 +224,7 @@ class TrackProcessor {
           this.buffer[i] = value / 0x7f_ff;
         }
 
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
         if (this.generator.readyState === "ended") {
           // ジェネレータ（ユーザに渡している処理結果トラック）がクローズ済み。
           // この状態で `controller.enqueue()` を呼び出すとエラーが発生するのでスキップする。

--- a/packages/noise-suppression/src/noise_suppression.ts
+++ b/packages/noise-suppression/src/noise_suppression.ts
@@ -1,4 +1,5 @@
-import { type DenoiseState, Rnnoise } from "@shiguredo/rnnoise-wasm";
+import { Rnnoise } from "@shiguredo/rnnoise-wasm";
+import type { DenoiseState } from "@shiguredo/rnnoise-wasm";
 
 /**
  * 音声トラックにノイズ抑制処理を適用するためのプロセッサ
@@ -41,13 +42,11 @@ class NoiseSuppressionProcessor {
    */
   async startProcessing(track: MediaStreamAudioTrack): Promise<MediaStreamAudioTrack> {
     if (this.isProcessing()) {
-      throw Error("Noise suppression processing has already started.");
+      throw new Error("Noise suppression processing has already started.");
     }
 
-    if (this.rnnoise === undefined) {
-      // 最初の `startProcessing` 呼び出し時に RNNoise をロードする
-      this.rnnoise = await Rnnoise.load();
-    }
+    // 最初の `startProcessing` 呼び出し時に RNNoise をロードする
+    this.rnnoise ??= await Rnnoise.load();
 
     const denoiseState = this.rnnoise.createDenoiseState();
 
@@ -131,13 +130,13 @@ class TrackProcessor {
     this.abortController = new AbortController();
     this.denoiseState = denoiseState;
 
-    // generator / processor インスタンスを生成（まだ処理は開始しない）
+    // Generator / processor インスタンスを生成（まだ処理は開始しない）
     this.generator = new MediaStreamTrackGenerator({ kind: "audio" });
     this.processor = new MediaStreamTrackProcessor({ track: this.track });
   }
 
   startProcessing(): MediaStreamAudioTrack {
-    const signal = this.abortController.signal;
+    const { signal } = this.abortController;
     this.processor.readable
       .pipeThrough(
         new TransformStream({
@@ -148,17 +147,17 @@ class TrackProcessor {
         { signal },
       )
       .pipeTo(this.generator.writable)
-      .catch((e) => {
+      .catch((error) => {
         if (signal.aborted) {
           console.debug("Shutting down streams after abort.");
         } else {
-          console.warn("Error from stream transform:", e);
+          console.warn("Error from stream transform:", error);
         }
-        this.processor.readable.cancel(e).catch((e) => {
-          console.warn("Failed to cancel `MediaStreamTrackProcessor`:", e);
+        this.processor.readable.cancel(error).catch((error) => {
+          console.warn("Failed to cancel `MediaStreamTrackProcessor`:", error);
         });
-        this.generator.writable.abort(e).catch((e) => {
-          console.warn("Failed to abort `MediaStreamTrackGenerator`:", e);
+        this.generator.writable.abort(error).catch((error) => {
+          console.warn("Failed to abort `MediaStreamTrackGenerator`:", error);
         });
       });
     return this.generator;
@@ -174,7 +173,7 @@ class TrackProcessor {
     controller: TransformStreamDefaultController<AudioData>,
   ): void {
     if (data.numberOfChannels !== 1) {
-      throw Error("Noise suppression for stereo channel has not been supported yet.");
+      throw new Error("Noise suppression for stereo channel has not been supported yet.");
     }
     if (data.format !== "f32-planar") {
       // https://www.w3.org/TR/webcodecs/#audio-buffer-arrangement を見ると、
@@ -183,7 +182,7 @@ class TrackProcessor {
       //
       // MEMO: `AutoData.copyTo`で`format`が指定できるので、もしかしたら
       //       そのオプションで"f32-planar"を指定しておけば、後続の処理は共通化できるかもしれない。
-      throw Error(`Unsupported audio data format ${data.format}."`);
+      throw new Error(`Unsupported audio data format ${data.format}."`);
     }
 
     if (this.bufferFrameCount === 0) {
@@ -197,9 +196,9 @@ class TrackProcessor {
         data.numberOfFrames - frameOffset,
       );
       data.copyTo(this.buffer.subarray(this.bufferFrameCount), {
-        planeIndex: 0,
-        frameOffset,
         frameCount,
+        frameOffset,
+        planeIndex: 0,
       });
       this.bufferFrameCount += frameCount;
       frameOffset += frameCount;
@@ -207,15 +206,15 @@ class TrackProcessor {
       if (this.bufferFrameCount === this.frameSize) {
         // RNNoiseが16-bit PCMを仮定しているので変換
         for (const [i, value] of this.buffer.entries()) {
-          this.buffer[i] = value * 0x7fff;
+          this.buffer[i] = value * 0x7f_ff;
         }
 
         // ノイズ低減処理
         this.denoiseState.processFrame(this.buffer);
 
-        // f32-planarに戻す
+        // F32-planarに戻す
         for (const [i, value] of this.buffer.entries()) {
-          this.buffer[i] = value / 0x7fff;
+          this.buffer[i] = value / 0x7f_ff;
         }
 
         if (this.generator.readyState === "ended") {
@@ -231,12 +230,12 @@ class TrackProcessor {
 
         controller.enqueue(
           new AudioData({
-            format: data.format,
-            sampleRate: data.sampleRate,
-            numberOfFrames: this.frameSize,
-            numberOfChannels: data.numberOfChannels,
-            timestamp: this.nextTimestamp,
             data: this.buffer,
+            format: data.format,
+            numberOfChannels: data.numberOfChannels,
+            numberOfFrames: this.frameSize,
+            sampleRate: data.sampleRate,
+            timestamp: this.nextTimestamp,
           }),
         );
         this.buffer = new Float32Array(this.frameSize);

--- a/packages/noise-suppression/vite.config.mjs
+++ b/packages/noise-suppression/vite.config.mjs
@@ -1,5 +1,5 @@
+import { defineConfig } from "vite-plus";
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import pkg from "./package.json";
 
@@ -14,21 +14,21 @@ const banner = `/**
 
 export default defineConfig({
   build: {
-    minify: "esbuild",
-    target: "es2023",
     emptyOutDir: true,
-    manifest: true,
     lib: {
       entry: resolve(__dirname, "src/noise_suppression.ts"),
+      fileName: "noise_suppression",
       formats: ["es"],
       name: "Shiguredo",
-      fileName: "noise_suppression",
     },
+    manifest: true,
+    minify: "esbuild",
     rollupOptions: {
       output: {
         banner: banner,
       },
     },
+    target: "es2023",
   },
   plugins: [
     dts({

--- a/packages/video-track-processor/package.json
+++ b/packages/video-track-processor/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vp build",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -54,10 +54,12 @@ class VideoTrackProcessor {
     return this.trackProcessor !== undefined;
   }
 
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getOriginalTrack(): MediaStreamVideoTrack | undefined {
     return this.originalTrack;
   }
 
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getProcessedTrack(): MediaStreamVideoTrack | undefined {
     return this.processedTrack;
   }
@@ -143,11 +145,13 @@ class BreakoutBoxProcessor extends Processor {
 
   async startProcessing(): Promise<MediaStreamVideoTrack> {
     const { signal } = this.abortController;
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     this.processor.readable
       .pipeThrough(
         new TransformStream({
           transform: async (frame, controller) => {
             this.recordStartFrame();
+            // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
             if (this.generator.readyState === "ended") {
               // ジェネレータ（ユーザに渡している処理結果トラック）がクローズ済み。
               // この状態で `controller.enqueue()` を呼び出すとエラーが発生するのでスキップする。
@@ -161,6 +165,7 @@ class BreakoutBoxProcessor extends Processor {
             const { timestamp, duration } = frame;
             // HTMLVideoElementと等価に扱いつつ、mediapipeに渡す際のパフォーマンスが良いのでImageBitmapを使う。
             const image = await createImageBitmap(frame);
+            // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
             frame.close();
             const processedImageCanvas = await this.callback(image);
             image.close();
@@ -172,16 +177,20 @@ class BreakoutBoxProcessor extends Processor {
         }),
         { signal },
       )
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
       .pipeTo(this.generator.writable)
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
       .catch((error) => {
         if (signal.aborted) {
           console.debug("Shutting down streams after abort.");
         } else {
           console.warn("Error from stream transform:", error);
         }
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
         this.processor.readable.cancel(error).catch((error) => {
           console.warn("Failed to cancel `MediaStreamTrackProcessor`:", error);
         });
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
         this.generator.writable.abort(error).catch((error) => {
           console.warn("Failed to abort `MediaStreamTrackGenerator`:", error);
         });
@@ -214,7 +223,9 @@ class RequestVideoFrameCallbackProcessor extends Processor {
 
     // 処理後の映像フレームを書き込むための canvas を生成する
     // CaptureStream() を使いたいので OffscreenCanvas にはできない
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     const width = track.getSettings().width ?? 0;
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     const height = track.getSettings().height ?? 0;
     this.canvas = document.createElement("canvas");
     this.canvas.width = width;

--- a/packages/video-track-processor/src/video_track_processor.ts
+++ b/packages/video-track-processor/src/video_track_processor.ts
@@ -25,7 +25,7 @@ class VideoTrackProcessor {
     callback: ProcessImageCallback,
   ): Promise<MediaStreamVideoTrack> {
     if (this.isProcessing()) {
-      throw Error("Video track processing has already started.");
+      throw new Error("Video track processing has already started.");
     }
 
     if (BreakoutBoxProcessor.isSupported()) {
@@ -33,7 +33,7 @@ class VideoTrackProcessor {
     } else if (RequestVideoFrameCallbackProcessor.isSupported()) {
       this.trackProcessor = new RequestVideoFrameCallbackProcessor(track, callback);
     } else {
-      throw Error("Unsupported browser");
+      throw new Error("Unsupported browser");
     }
     this.originalTrack = track;
     this.processedTrack = await this.trackProcessor.startProcessing();
@@ -129,7 +129,7 @@ class BreakoutBoxProcessor extends Processor {
     // 処理を停止するための AbortController を初期化
     this.abortController = new AbortController();
 
-    // generator / processor インスタンスを生成（まだ処理は開始しない）
+    // Generator / processor インスタンスを生成（まだ処理は開始しない）
     this.generator = new MediaStreamTrackGenerator({ kind: "video" });
     this.processor = new MediaStreamTrackProcessor({ track: this.track });
   }
@@ -141,8 +141,8 @@ class BreakoutBoxProcessor extends Processor {
     );
   }
 
-  startProcessing(): Promise<MediaStreamVideoTrack> {
-    const signal = this.abortController.signal;
+  async startProcessing(): Promise<MediaStreamVideoTrack> {
+    const { signal } = this.abortController;
     this.processor.readable
       .pipeThrough(
         new TransformStream({
@@ -165,7 +165,7 @@ class BreakoutBoxProcessor extends Processor {
             const processedImageCanvas = await this.callback(image);
             image.close();
             controller.enqueue(
-              new VideoFrame(processedImageCanvas, { timestamp, duration } as VideoFrameInit),
+              new VideoFrame(processedImageCanvas, { duration, timestamp } as VideoFrameInit),
             );
             this.recordStopFrame();
           },
@@ -173,20 +173,20 @@ class BreakoutBoxProcessor extends Processor {
         { signal },
       )
       .pipeTo(this.generator.writable)
-      .catch((e) => {
+      .catch((error) => {
         if (signal.aborted) {
           console.debug("Shutting down streams after abort.");
         } else {
-          console.warn("Error from stream transform:", e);
+          console.warn("Error from stream transform:", error);
         }
-        this.processor.readable.cancel(e).catch((e) => {
-          console.warn("Failed to cancel `MediaStreamTrackProcessor`:", e);
+        this.processor.readable.cancel(error).catch((error) => {
+          console.warn("Failed to cancel `MediaStreamTrackProcessor`:", error);
         });
-        this.generator.writable.abort(e).catch((e) => {
-          console.warn("Failed to abort `MediaStreamTrackGenerator`:", e);
+        this.generator.writable.abort(error).catch((error) => {
+          console.warn("Failed to abort `MediaStreamTrackGenerator`:", error);
         });
       });
-    return Promise.resolve(this.generator);
+    return this.generator;
   }
 
   stopProcessing() {
@@ -205,7 +205,7 @@ class RequestVideoFrameCallbackProcessor extends Processor {
   constructor(track: MediaStreamVideoTrack, callback: ProcessImageCallback) {
     super(track, callback);
 
-    // requestVideoFrameCallbackHandle()` はトラックではなくビデオ単位のメソッドなので
+    // RequestVideoFrameCallbackHandle()` はトラックではなくビデオ単位のメソッドなので
     // 内部的に HTMLVideoElement を生成する
     this.video = document.createElement("video");
     this.video.muted = true;
@@ -213,15 +213,15 @@ class RequestVideoFrameCallbackProcessor extends Processor {
     this.video.srcObject = new MediaStream([track]);
 
     // 処理後の映像フレームを書き込むための canvas を生成する
-    // captureStream() を使いたいので OffscreenCanvas にはできない
-    const width = track.getSettings().width || 0;
-    const height = track.getSettings().height || 0;
+    // CaptureStream() を使いたいので OffscreenCanvas にはできない
+    const width = track.getSettings().width ?? 0;
+    const height = track.getSettings().height ?? 0;
     this.canvas = document.createElement("canvas");
     this.canvas.width = width;
     this.canvas.height = height;
     const canvasCtx = this.canvas.getContext("2d");
     if (canvasCtx === null) {
-      throw Error("Failed to create 2D canvas context");
+      throw new Error("Failed to create 2D canvas context");
     }
     this.canvasCtx = canvasCtx;
   }
@@ -233,13 +233,15 @@ class RequestVideoFrameCallbackProcessor extends Processor {
   async startProcessing(): Promise<MediaStreamVideoTrack> {
     this.requestVideoFrameCallbackHandle = this.video.requestVideoFrameCallback(() => {
       this.recordStartFrame();
-      this.onFrame().catch((e) => console.warn("Error: ", e));
+      this.onFrame().catch((error) => {
+        console.warn("Error:", error);
+      });
       this.recordStopFrame();
     });
     await this.video.play();
 
     const stream = this.canvas.captureStream();
-    return Promise.resolve(stream.getVideoTracks()[0]);
+    return stream.getVideoTracks()[0];
   }
 
   stopProcessing() {
@@ -256,9 +258,10 @@ class RequestVideoFrameCallbackProcessor extends Processor {
 
     const processedImageCanvas = await this.callback(this.video);
     this.canvasCtx.drawImage(processedImageCanvas, 0, 0);
-    // @ts-ignore
     this.requestVideoFrameCallbackHandle = this.video.requestVideoFrameCallback(() => {
-      this.onFrame().catch((e) => console.warn("Error: ", e));
+      this.onFrame().catch((error) => {
+        console.warn("Error:", error);
+      });
     });
   }
 }

--- a/packages/video-track-processor/vite.config.mjs
+++ b/packages/video-track-processor/vite.config.mjs
@@ -1,5 +1,5 @@
+import { defineConfig } from "vite-plus";
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import pkg from "./package.json";
 
@@ -14,21 +14,21 @@ const banner = `/**
 
 export default defineConfig({
   build: {
-    minify: "esbuild",
-    target: "es2023",
     emptyOutDir: true,
-    manifest: true,
     lib: {
       entry: resolve(__dirname, "src/video_track_processor.ts"),
+      fileName: "video_track_processor",
       formats: ["es"],
       name: "Shiguredo",
-      fileName: "video_track_processor",
     },
+    manifest: true,
+    minify: "esbuild",
     rollupOptions: {
       output: {
         banner: banner,
       },
     },
+    target: "es2023",
   },
   plugins: [
     dts({

--- a/packages/virtual-background/package.json
+++ b/packages/virtual-background/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@mediapipe/selfie_segmentation": "0.1.1675465747",
-    "stackblur-canvas": "3.0.0",
+    "stackblur-canvas": "3.0.1",
     "video-track-processor": "workspace:*"
   },
   "devDependencies": {

--- a/packages/virtual-background/package.json
+++ b/packages/virtual-background/package.json
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vp build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/virtual-background/src/stackblur-canvas.d.ts
+++ b/packages/virtual-background/src/stackblur-canvas.d.ts
@@ -1,5 +1,5 @@
-// stackblur-canvas@3.0.0 の package.json "exports" に "types" エントリが含まれていないため、
-// moduleResolution: "bundler" では同梱の index.d.ts が解決できない。
+// Stackblur-canvas@3.0.0 の package.json "exports" に "types" エントリが含まれていないため、
+// ModuleResolution: "bundler" では同梱の index.d.ts が解決できない。
 // ライブラリ側で修正されるまでの回避策として、型宣言をここで再定義する。
 declare module "stackblur-canvas" {
   export class BlurStack {

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -156,7 +156,9 @@ class VirtualBackgroundProcessor {
     track: MediaStreamVideoTrack,
     options: VirtualBackgroundProcessorOptions = {},
   ): Promise<MediaStreamVideoTrack> {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     const initialWidth = track.getSettings().width ?? 0;
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
     const initialHeight = track.getSettings().height ?? 0;
     const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
@@ -240,6 +242,7 @@ class VirtualBackgroundProcessor {
    *
    * @returns 処理適用中の場合は映像トラック、それ以外なら `undefined`
    */
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getOriginalTrack(): MediaStreamVideoTrack | undefined {
     return this.trackProcessor.getOriginalTrack();
   }
@@ -254,6 +257,7 @@ class VirtualBackgroundProcessor {
    *
    * @returns 処理適用中の場合は映像トラック、それ以外なら `undefined`
    */
+  // oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents -- oxlint が @types/dom-mediacapture-transform のグローバル型を解決できないための偽陽性
   getProcessedTrack(): MediaStreamVideoTrack | undefined {
     return this.trackProcessor.getProcessedTrack();
   }

--- a/packages/virtual-background/src/virtual_background.ts
+++ b/packages/virtual-background/src/virtual_background.ts
@@ -1,7 +1,7 @@
-import {
-  SelfieSegmentation,
-  type SelfieSegmentationConfig,
-  type Results as SelfieSegmentationResults,
+import { SelfieSegmentation } from "@mediapipe/selfie_segmentation";
+import type {
+  SelfieSegmentationConfig,
+  Results as SelfieSegmentationResults,
 } from "@mediapipe/selfie_segmentation";
 import { VideoTrackProcessor } from "../../video-track-processor/src/video_track_processor";
 import * as StackBlur from "stackblur-canvas";
@@ -76,8 +76,8 @@ interface ImageRegion {
 function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
   let x = 0;
   let y = 0;
-  let width = backgroundImage.width;
-  let height = backgroundImage.height;
+  let { width } = backgroundImage;
+  let { height } = backgroundImage;
 
   const videoFrameRatio = videoFrame.width / videoFrame.height;
   const backgroundImageRatio = backgroundImage.width / backgroundImage.height;
@@ -91,7 +91,7 @@ function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: Image
     width = Math.round(newWidth);
   }
 
-  return { x, y, width, height };
+  return { height, width, x, y };
 }
 
 /**
@@ -101,7 +101,7 @@ function cropBackgroundImageCenter(videoFrame: ImageSize, backgroundImage: Image
  * 背景画像と処理対象映像のアスペクト比が異なる場合には、背景画像が映像に合わせて引き伸ばされます
  */
 function fillBackgroundImage(_videoFrame: ImageSize, backgroundImage: ImageSize): ImageRegion {
-  return { x: 0, y: 0, width: backgroundImage.width, height: backgroundImage.height };
+  return { height: backgroundImage.height, width: backgroundImage.width, x: 0, y: 0 };
 }
 
 /**
@@ -122,9 +122,7 @@ class VirtualBackgroundProcessor {
     // セグメンテーションモデルのロード準備
     const config: SelfieSegmentationConfig = {};
     const trimmedAssetsPath = trimLastSlash(assetsPath);
-    config.locateFile = (file: string) => {
-      return `${trimmedAssetsPath}/${file}`;
-    };
+    config.locateFile = (file: string) => `${trimmedAssetsPath}/${file}`;
     this.segmentation = new SelfieSegmentation(config);
   }
 
@@ -158,15 +156,15 @@ class VirtualBackgroundProcessor {
     track: MediaStreamVideoTrack,
     options: VirtualBackgroundProcessorOptions = {},
   ): Promise<MediaStreamVideoTrack> {
-    const initialWidth = track.getSettings().width || 0;
-    const initialHeight = track.getSettings().height || 0;
+    const initialWidth = track.getSettings().width ?? 0;
+    const initialHeight = track.getSettings().height ?? 0;
     const canvas = createOffscreenCanvas(initialWidth, initialHeight);
     const canvasCtx = canvas.getContext("2d", {
       desynchronized: true,
       willReadFrequently: false, // ここをtrueにするとCPU-GPUメモリ転送が発生して遅くなる
     }) as OffscreenCanvasRenderingContext2D | null;
     if (canvasCtx === null) {
-      throw Error("Failed to create 2D canvas context");
+      throw new Error("Failed to create 2D canvas context");
     }
 
     // Safari での背景ぼかし用に一時作業用の canvas を作っておく
@@ -179,7 +177,7 @@ class VirtualBackgroundProcessor {
         willReadFrequently: true,
       });
       if (ctx === null) {
-        throw Error("Failed to create 2D canvas context");
+        throw new Error("Failed to create 2D canvas context");
       }
       blurCanvasCtx = ctx as OffscreenCanvasRenderingContext2D;
     }
@@ -204,7 +202,7 @@ class VirtualBackgroundProcessor {
     return this.trackProcessor.startProcessing(
       track,
       async (image: ImageBitmap | HTMLVideoElement) => {
-        // @ts-ignore TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
+        // @ts-expect-error TS2322: 「`image`の型が合っていない」と怒られるけれど、動作はするので一旦無視
         await this.segmentation.send({ image });
 
         return canvas;
@@ -313,8 +311,8 @@ class VirtualBackgroundProcessor {
     }
 
     if (options.backgroundImage !== undefined) {
-      const decideRegion = options.backgroundImageRegion || cropBackgroundImageCenter;
-      const region = decideRegion({ width, height }, options.backgroundImage);
+      const decideRegion = options.backgroundImageRegion ?? cropBackgroundImageCenter;
+      const region = decideRegion({ height, width }, options.backgroundImage);
       tmpCanvasCtx.drawImage(
         options.backgroundImage,
         region.x,
@@ -331,7 +329,7 @@ class VirtualBackgroundProcessor {
     }
 
     if (blurCanvasCtx !== undefined) {
-      // @ts-ignore
+      // @ts-expect-error
       StackBlur.canvasRGB(tmpCanvasCtx.canvas, 0, 0, width, height, options.blurRadius);
       canvasCtx.drawImage(tmpCanvasCtx.canvas, 0, 0, width, height);
     }
@@ -372,19 +370,19 @@ function createOffscreenCanvas(width: number, height: number): OffscreenCanvas |
 
 function browser(): string {
   const ua = window.navigator.userAgent.toLocaleLowerCase();
-  if (ua.indexOf("edge") !== -1) {
+  if (ua.includes("edge")) {
     return "edge";
   }
-  if (ua.indexOf("chrome") !== -1 && ua.indexOf("edge") === -1) {
+  if (ua.includes("chrome") && !ua.includes("edge")) {
     return "chrome";
   }
-  if (ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1) {
+  if (ua.includes("safari") && !ua.includes("chrome")) {
     return "safari";
   }
-  if (ua.indexOf("opera") !== -1) {
+  if (ua.includes("opera")) {
     return "opera";
   }
-  if (ua.indexOf("firefox") !== -1) {
+  if (ua.includes("firefox")) {
     return "firefox";
   }
   return "unknown";

--- a/packages/virtual-background/vite.config.mjs
+++ b/packages/virtual-background/vite.config.mjs
@@ -1,8 +1,8 @@
-import fs from "node:fs";
-import { resolve } from "node:path";
-import { defineConfig } from "vite";
-import dts from "vite-plugin-dts";
+import { defineConfig } from "vite-plus";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import dts from "vite-plugin-dts";
+import fs from "node:fs";
+import path from "node:path";
 import pkg from "./package.json";
 
 const banner = `/**
@@ -14,24 +14,37 @@ const banner = `/**
  **/
 `;
 
+// https://github.com/google/mediapipe/issues/2883 が対応されないので、ワークアラウンドを行う
+const mediapipeWorkaround = () => ({
+  load(id) {
+    if (path.basename(id) === "selfie_segmentation.js") {
+      let code = fs.readFileSync(id, "utf8");
+      code += "exports.SelfieSegmentation = SelfieSegmentation;";
+      return { code };
+    }
+    return null;
+  },
+  name: "mediapipe_workaround",
+});
+
 export default defineConfig({
   build: {
-    minify: "esbuild",
-    target: "es2023",
     emptyOutDir: true,
-    manifest: true,
     lib: {
-      entry: resolve(__dirname, "src/virtual_background.ts"),
+      entry: path.resolve(__dirname, "src/virtual_background.ts"),
+      fileName: "virtual_background",
       formats: ["es"],
       name: "Shiguredo",
-      fileName: "virtual_background",
     },
+    manifest: true,
+    minify: "esbuild",
     rollupOptions: {
       output: {
         banner: banner,
       },
-      plugins: [mediapipeWorkaround],
+      plugins: [mediapipeWorkaround()],
     },
+    target: "es2023",
   },
   plugins: [
     dts({
@@ -40,8 +53,9 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
+          dest: ".",
           src: [
-            // node_modulesの場所が変わることがあるので、両方のパターンに対応しておく
+            // Node_modules の場所が変わることがあるので、両方のパターンに対応しておく
             "./node_modules/@mediapipe/selfie_segmentation/*.wasm",
             "./node_modules/@mediapipe/selfie_segmentation/*.tflite",
             "./node_modules/@mediapipe/selfie_segmentation/*.binarypb",
@@ -52,24 +66,8 @@ export default defineConfig({
             "../../node_modules/@mediapipe/selfie_segmentation/*.binarypb",
             "../../node_modules/@mediapipe/selfie_segmentation/*wasm_bin.js",
           ],
-          dest: ".",
         },
       ],
     }),
   ],
 });
-
-// https://github.com/google/mediapipe/issues/2883 が対応されないので、ワークアラウンドを行う
-function mediapipeWorkaround() {
-  return {
-    name: "mediapipe_workaround",
-    load(id) {
-      if (path.basename(id) === "selfie_segmentation.js") {
-        let code = fs.readFileSync(id, "utf-8");
-        code += "exports.SelfieSegmentation = SelfieSegmentation;";
-        return { code };
-      }
-      return null;
-    },
-  };
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,17 +16,17 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@0.1.11
-        version: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.12
+        version: '@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3)
+        version: 4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3)
       vite-plugin-static-copy:
-        specifier: 3.2.0
-        version: 3.2.0(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))
+        specifier: 3.3.0
+        version: 3.3.0(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))
       vite-plus:
-        specifier: 0.1.11
-        version: 0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+        specifier: 0.1.12
+        version: 0.1.12(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
 
   examples:
     dependencies:
@@ -60,8 +60,8 @@ importers:
         specifier: 0.1.1675465747
         version: 0.1.1675465747
       stackblur-canvas:
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 3.0.1
+        version: 3.0.1
       video-track-processor:
         specifier: workspace:*
         version: link:../video-track-processor
@@ -80,8 +80,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -254,8 +254,8 @@ packages:
   '@microsoft/api-extractor-model@7.33.4':
     resolution: {integrity: sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==}
 
-  '@microsoft/api-extractor@7.57.6':
-    resolution: {integrity: sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==}
+  '@microsoft/api-extractor@7.57.7':
+    resolution: {integrity: sha512-kmnmVs32MFWbV5X6BInC1/TfCs7y1ugwxv1xHsAIj/DyUfoe7vtO0alRUgbQa57+yRGHBBjlNcEk33SCAt5/dA==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.18.1':
@@ -393,33 +393,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.16.0':
-    resolution: {integrity: sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==}
+  '@oxlint-tsgolint/darwin-arm64@0.17.0':
+    resolution: {integrity: sha512-z3XwCDuOAKgk7bO4y5tyH8Zogwr51G56R0XGKC3tlAbrAq8DecoxAd3qhRZqWBMG2Gzl5bWU3Ghu7lrxuLPzYw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.16.0':
-    resolution: {integrity: sha512-VJo29XOzdkalvCTiE2v6FU3qZlgHaM8x8hUEVJGPU2i5W+FlocPpmn00+Ld2n7Q0pqIjyD5EyvZ5UmoIEJMfqg==}
+  '@oxlint-tsgolint/darwin-x64@0.17.0':
+    resolution: {integrity: sha512-TZgVXy0MtI8nt0MYiceuZhHPwHcwlIZ/YwzFTAKrgdHiTvVzFbqHVdXi5wbZfT/o1nHGw9fbGWPlb6qKZ4uZ9Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.16.0':
-    resolution: {integrity: sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ==}
+  '@oxlint-tsgolint/linux-arm64@0.17.0':
+    resolution: {integrity: sha512-IDfhFl/Y8bjidCvAP6QAxVyBsl78TmfCHlfjtEv2XtJXgYmIwzv6muO18XMp74SZ2qAyD4y2n2dUedrmghGHeA==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.16.0':
-    resolution: {integrity: sha512-XQSwVUsnwLokMhe1TD6IjgvW5WMTPzOGGkdFDtXWQmlN2YeTw94s/NN0KgDrn2agM1WIgAenEkvnm0u7NgwEyw==}
+  '@oxlint-tsgolint/linux-x64@0.17.0':
+    resolution: {integrity: sha512-Bgdgqx/m8EnfjmmlRLEeYy9Yhdt1GdFrMr5mTu/NyLRGkB1C9VLAikdxB7U9QambAGTAmjMbHNFDFk8Vx69Huw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.16.0':
-    resolution: {integrity: sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg==}
+  '@oxlint-tsgolint/win32-arm64@0.17.0':
+    resolution: {integrity: sha512-dO6wyKMDqFWh1vwr+zNZS7/ovlfGgl4S3P1LDy4CKjP6V6NGtdmEwWkWax8j/I8RzGZdfXKnoUfb/qhVg5bx0w==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.16.0':
-    resolution: {integrity: sha512-1ufk8cgktXJuJZHKF63zCHAkaLMwZrEXnZ89H2y6NO85PtOXqu4zbdNl0VBpPP3fCUuUBu9RvNqMFiv0VsbXWA==}
+  '@oxlint-tsgolint/win32-x64@0.17.0':
+    resolution: {integrity: sha512-lPGYFp3yX2nh6hLTpIuMnJbZnt3Df42VkoA/fSkMYi2a/LXdDytQGpgZOrb5j47TICARd34RauKm0P3OA4Oxbw==}
     cpu: [x64]
     os: [win32]
 
@@ -756,13 +756,13 @@ packages:
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
-  '@voidzero-dev/vite-plus-core@0.1.11':
-    resolution: {integrity: sha512-feyYRSg3u8acYNC1fF4EGfgYZm2efZB8YWTjz4NrU0Ulhlni1C6COMwHSDVpu9F4Jh+WcSsBWL3ZC1WvLa7jCw==}
+  '@voidzero-dev/vite-plus-core@0.1.12':
+    resolution: {integrity: sha512-j8YNe7A+8JcSoddztf5whvom/yJ7OKUO3Y5a3UoLIUmOL8YEKVv5nPANrxJ7eaFfHJoMnBEwzBpq1YVZ+H3uPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.2
-      '@tsdown/exe': 0.21.2
+      '@tsdown/css': 0.21.3
+      '@tsdown/exe': 0.21.3
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.0.0-alpha.31
       esbuild: ^0.27.0
@@ -816,34 +816,34 @@ packages:
       yaml:
         optional: true
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.11':
-    resolution: {integrity: sha512-ENokEkMhDMJ9nM/tUDAXvtah/P3cAnEbkeKCCxJgFvTTGnGM8eBvP2qpJeTrfhy9ndIWihcsfMufszinLsfhUg==}
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.12':
+    resolution: {integrity: sha512-tYQrfmcLxIqqr/de00oN7ayu+rYobEOjyR9AxoeJoNUqRyNQCdT0A5vg78kJNPaQCyL6ctgRRvpEKr0WHVmduQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.11':
-    resolution: {integrity: sha512-gOSGYtXq5qigDsiW+oCrefv4K8WUSnZ5vH+kPHDvpsMXlqxR0rY6xrJgkJ2tCkWdCig8YHVDascSV/cj4nGwsw==}
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.12':
+    resolution: {integrity: sha512-852hO/Onx9Z5u0tOYOVEUVzYJUmWdlHeqYnNT6pj0IClgVp0+KSabxr7A2paTWEFWp6XbKWvqw5Y5cVwUV3A6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.11':
-    resolution: {integrity: sha512-aDVe1vvhtXBqZdmCiCSm3DUl5/O+x5CeAcjPPTLSsEX79cSfvkD0UU26lQ8eX+pr3xVDEocJTtTLmOMVImGlyA==}
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.12':
+    resolution: {integrity: sha512-/gTh4tGyJKCNBn9SZUs3sq9QVRUmyuyseZefBgS223QRxdwFaxc7tIKaw91X59WXXYOzUYZOD5zsTcaIF4hc9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.11':
-    resolution: {integrity: sha512-rkaKCGq/CFML2M7c0ixUOuhE6qi961x84/ZFQhkUy2MJw3RP7R/M1BDyWr2qEq20SgRWLkffcWMni3P2JnmrBw==}
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.12':
+    resolution: {integrity: sha512-9oN9ITjK/Xq9Werx+6G6jnI3+F1S3g9lB36J1VAHyRlAEtuiCDV0E3YMoW2O7KzM/PlodZIZ8LStVkH7aA5ZCw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-test@0.1.11':
-    resolution: {integrity: sha512-3kBfi/LyPOGnLCmvYtgM5GZVAyiJiYjgdm9Fu9WLLl56zcSljj0TBG19eaKY6v/j2VJ+7o80n/A/MPz46lzMFA==}
+  '@voidzero-dev/vite-plus-test@0.1.12':
+    resolution: {integrity: sha512-EE8Y2vQvqS4c/1qSa7qlhUY9koAG6wYev0NFAtDZsijQCHUqE7nYXGJYnyUInAE6GX4zlQDGg7tf2DAl+CISYw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -867,14 +867,14 @@ packages:
       jsdom:
         optional: true
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.11':
-    resolution: {integrity: sha512-MerozzH8QYY+V5l6ZQq+vrtx75rnPlmc+TauH5hL08oEWx7ScwfrNKyamnv5rg7HWBx/ryuaYaJCjODOu7MjSg==}
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.12':
+    resolution: {integrity: sha512-JanAb6Y+6BmPhKNLvpZB/syeyY99bt7EPJCaLlbaCt3V0Y2Iw7c7dWBM4Sg4GZ7szGYdGw385fRz0n2M32f1rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.11':
-    resolution: {integrity: sha512-ubGlfvkfWT4Eivg3O2lxMyA6h7u1XZm4XdW3MUZIXXd9Q/iIRVJdSsEg78C/OZ3e8Qofszsro6P8ZrQo8ROQxg==}
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.12':
+    resolution: {integrity: sha512-Ei/UtTTp7UgeEGyV83jhDpSMXhwaZZzfS7Xiaj+zj80GGOwsBre0i+oHGZ7+TuVsZ7Im0sD8IZ9enCpKpV//AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -888,11 +888,11 @@ packages:
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
-  '@vue/compiler-core@3.5.29':
-    resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
+  '@vue/compiler-core@3.5.30':
+    resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
 
-  '@vue/compiler-dom@3.5.29':
-    resolution: {integrity: sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==}
+  '@vue/compiler-dom@3.5.30':
+    resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -905,8 +905,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/shared@3.5.29':
-    resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+  '@vue/shared@3.5.30':
+    resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1046,8 +1046,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  fs-extra@11.3.3:
-    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+  fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
@@ -1204,16 +1204,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mlly@1.8.0:
-    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+  mlly@1.8.1:
+    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1242,8 +1242,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.16.0:
-    resolution: {integrity: sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==}
+  oxlint-tsgolint@0.17.0:
+    resolution: {integrity: sha512-TdrKhDZCgEYqONFo/j+KvGan7/k3tP5Ouz88wCqpOvJtI2QmcLfGsm1fcMvDnTik48Jj6z83IJBqlkmK9DnY1A==}
     hasBin: true
 
   oxlint@1.55.0:
@@ -1351,8 +1351,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  stackblur-canvas@3.0.0:
-    resolution: {integrity: sha512-BTbpAj0SNgpTwqKS3aacbI8p3/Ix50i8jAKome/YnM29DZVgriOZ+3V5GAf73nukjZY7xTf0TxdTgFKh4vsAKQ==}
+  stackblur-canvas@3.0.1:
+    resolution: {integrity: sha512-eJpxkL5PR39dioN3ZapIIhkjQd01wxcigCnBURzbRofZk5M+cHZUA8VwBelHLhsFW20gO9vdH6hFRIekA+jJfA==}
     engines: {node: '>=0.1.16'}
 
   std-env@4.0.0:
@@ -1426,14 +1426,14 @@ packages:
       vite:
         optional: true
 
-  vite-plugin-static-copy@3.2.0:
-    resolution: {integrity: sha512-g2k9z8B/1Bx7D4wnFjPLx9dyYGrqWMLTpwTtPHhcU+ElNZP2O4+4OsyaficiDClus0dzVhdGvoGFYMJxoXZ12Q==}
+  vite-plugin-static-copy@3.3.0:
+    resolution: {integrity: sha512-XiAtZcev7nppxNFgKoD55rfL+ukVp/RtrnTJONRwRuzv/B2FK2h2ZRCYjvxhwBV/Oarse83SiyXBSxMTfeEM0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  vite-plus@0.1.11:
-    resolution: {integrity: sha512-mDUbWirSUWtS/diQiq1QkHGsMNQWu90kSH5s7RWqVnV9s1PRxQ1IcH6mIeOG7YzPJlfO1vQbONZRsOfdyj9IKw==}
+  vite-plus@0.1.12:
+    resolution: {integrity: sha512-8s1RzomZkgrJRiwiYWGq3R0txFPYfBBJGp73XNHQnme0KTTVH5dNm/E2GNyBSMFJbeeF7eh1OSgqWVc2FpR6eA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1471,7 +1471,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -1570,7 +1570,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.6(@types/node@22.15.17)':
+  '@microsoft/api-extractor@7.57.7(@types/node@22.15.17)':
     dependencies:
       '@microsoft/api-extractor-model': 7.33.4(@types/node@22.15.17)
       '@microsoft/tsdoc': 0.16.0
@@ -1581,7 +1581,7 @@ snapshots:
       '@rushstack/ts-command-line': 5.3.3(@types/node@22.15.17)
       diff: 8.0.3
       lodash: 4.17.23
-      minimatch: 10.2.1
+      minimatch: 10.2.3
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -1659,22 +1659,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.40.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.16.0':
+  '@oxlint-tsgolint/darwin-arm64@0.17.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.16.0':
+  '@oxlint-tsgolint/darwin-x64@0.17.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.16.0':
+  '@oxlint-tsgolint/linux-arm64@0.17.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.16.0':
+  '@oxlint-tsgolint/linux-x64@0.17.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.16.0':
+  '@oxlint-tsgolint/win32-arm64@0.17.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.16.0':
+  '@oxlint-tsgolint/win32-x64@0.17.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.55.0':
@@ -1824,7 +1824,7 @@ snapshots:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.3
+      fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.11
@@ -1886,7 +1886,7 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
-  '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
+  '@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
     dependencies:
       '@oxc-project/runtime': 0.115.0
       '@oxc-project/types': 0.115.0
@@ -1899,23 +1899,23 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.0
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.11':
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.12':
     optional: true
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.11':
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.12':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.11':
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.12':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.11':
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.12':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
+  '@voidzero-dev/vite-plus-test@0.1.12(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      '@voidzero-dev/vite-plus-core': 0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -1925,7 +1925,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
       ws: 8.19.0
     optionalDependencies:
       '@types/node': 22.15.17
@@ -1950,10 +1950,10 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.11':
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.12':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.11':
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.12':
     optional: true
 
   '@volar/language-core@2.4.28':
@@ -1968,18 +1968,18 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue/compiler-core@3.5.29':
+  '@vue/compiler-core@3.5.30':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@vue/shared': 3.5.29
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.30
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.29':
+  '@vue/compiler-dom@3.5.30':
     dependencies:
-      '@vue/compiler-core': 3.5.29
-      '@vue/shared': 3.5.29
+      '@vue/compiler-core': 3.5.30
+      '@vue/shared': 3.5.30
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -1989,9 +1989,9 @@ snapshots:
   '@vue/language-core@2.2.0(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-dom': 3.5.30
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.29
+      '@vue/shared': 3.5.30
       alien-signals: 0.4.14
       minimatch: 9.0.9
       muggle-string: 0.4.1
@@ -1999,7 +1999,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/shared@3.5.29': {}
+  '@vue/shared@3.5.30': {}
 
   acorn@8.16.0: {}
 
@@ -2135,7 +2135,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  fs-extra@11.3.3:
+  fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -2243,7 +2243,7 @@ snapshots:
 
   local-pkg@1.1.2:
     dependencies:
-      mlly: 1.8.0
+      mlly: 1.8.1
       pkg-types: 2.3.0
       quansync: 0.2.11
 
@@ -2257,7 +2257,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  minimatch@10.2.1:
+  minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.4
 
@@ -2265,7 +2265,7 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  mlly@1.8.0:
+  mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
@@ -2308,16 +2308,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.40.0
       '@oxfmt/binding-win32-x64-msvc': 0.40.0
 
-  oxlint-tsgolint@0.16.0:
+  oxlint-tsgolint@0.17.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.16.0
-      '@oxlint-tsgolint/darwin-x64': 0.16.0
-      '@oxlint-tsgolint/linux-arm64': 0.16.0
-      '@oxlint-tsgolint/linux-x64': 0.16.0
-      '@oxlint-tsgolint/win32-arm64': 0.16.0
-      '@oxlint-tsgolint/win32-x64': 0.16.0
+      '@oxlint-tsgolint/darwin-arm64': 0.17.0
+      '@oxlint-tsgolint/darwin-x64': 0.17.0
+      '@oxlint-tsgolint/linux-arm64': 0.17.0
+      '@oxlint-tsgolint/linux-x64': 0.17.0
+      '@oxlint-tsgolint/win32-arm64': 0.17.0
+      '@oxlint-tsgolint/win32-x64': 0.17.0
 
-  oxlint@1.55.0(oxlint-tsgolint@0.16.0):
+  oxlint@1.55.0(oxlint-tsgolint@0.17.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.55.0
       '@oxlint/binding-android-arm64': 1.55.0
@@ -2338,7 +2338,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.55.0
       '@oxlint/binding-win32-ia32-msvc': 1.55.0
       '@oxlint/binding-win32-x64-msvc': 1.55.0
-      oxlint-tsgolint: 0.16.0
+      oxlint-tsgolint: 0.17.0
 
   p-map@7.0.4: {}
 
@@ -2363,7 +2363,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.1
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -2448,7 +2448,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  stackblur-canvas@3.0.0: {}
+  stackblur-canvas@3.0.1: {}
 
   std-env@4.0.0: {}
 
@@ -2490,9 +2490,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  vite-plugin-dts@4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3):
+  vite-plugin-dts@4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3):
     dependencies:
-      '@microsoft/api-extractor': 7.57.6(@types/node@22.15.17)
+      '@microsoft/api-extractor': 7.57.7(@types/node@22.15.17)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
@@ -2503,38 +2503,38 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-static-copy@3.2.0(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)):
+  vite-plugin-static-copy@3.3.0(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
 
-  vite-plus@0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0):
+  vite-plus@0.1.12(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0):
     dependencies:
       '@oxc-project/types': 0.115.0
-      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
-      '@voidzero-dev/vite-plus-test': 0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      '@voidzero-dev/vite-plus-core': 0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      '@voidzero-dev/vite-plus-test': 0.1.12(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.12(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
       cac: 6.7.14
       cross-spawn: 7.0.6
       oxfmt: 0.40.0
-      oxlint: 1.55.0(oxlint-tsgolint@0.16.0)
-      oxlint-tsgolint: 0.16.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
       picocolors: 1.1.1
     optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.11
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.11
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.11
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.11
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.11
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.11
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.12
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.12
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.12
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.12
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.12
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.12
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@edge-runtime/vm'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,27 +12,21 @@ importers:
         specifier: 0.1.11
         version: 0.1.11
     devDependencies:
-      oxfmt:
-        specifier: 0.36.0
-        version: 0.36.0
-      oxlint:
-        specifier: 1.51.0
-        version: 1.51.0(oxlint-tsgolint@0.15.0)
-      oxlint-tsgolint:
-        specifier: 0.15.0
-        version: 0.15.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 7.3.1
-        version: 7.3.1(@types/node@22.15.17)(yaml@2.8.0)
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.11
+        version: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.15.17)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.15.17)(yaml@2.8.0))
+        version: 4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3)
       vite-plugin-static-copy:
         specifier: 3.2.0
-        version: 3.2.0(vite@7.3.1(@types/node@22.15.17)(yaml@2.8.0))
+        version: 3.2.0(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))
+      vite-plus:
+        specifier: 0.1.11
+        version: 0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
 
   examples:
     dependencies:
@@ -270,279 +264,289 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@oxfmt/binding-android-arm-eabi@0.36.0':
-    resolution: {integrity: sha512-Z4yVHJWx/swHHjtr0dXrBZb6LxS+qNz1qdza222mWwPTUK4L790+5i3LTgjx3KYGBzcYpjaiZBw4vOx94dH7MQ==}
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@oxfmt/binding-android-arm-eabi@0.40.0':
+    resolution: {integrity: sha512-S6zd5r1w/HmqR8t0CTnGjFTBLDq2QKORPwriCHxo4xFNuhmOTABGjPaNvCJJVnrKBLsohOeiDX3YqQfJPF+FXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.36.0':
-    resolution: {integrity: sha512-3ElCJRFNPQl7jexf2CAa9XmAm8eC5JPrIDSjc9jSchkVSFTEqyL0NtZinBB2h1a4i4JgP1oGl/5G5n8YR4FN8Q==}
+  '@oxfmt/binding-android-arm64@0.40.0':
+    resolution: {integrity: sha512-/mbS9UUP/5Vbl2D6osIdcYiP0oie63LKMoTyGj5hyMCK/SFkl3EhtyRAfdjPvuvHC0SXdW6ePaTKkBSq1SNcIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.36.0':
-    resolution: {integrity: sha512-nak4znWCqIExKhYSY/mz/lWsqWIpdsS7o0+SRzXR1Q0m7GrMcG1UrF1pS7TLGZhhkf7nTfEF7q6oZzJiodRDuw==}
+  '@oxfmt/binding-darwin-arm64@0.40.0':
+    resolution: {integrity: sha512-wRt8fRdfLiEhnRMBonlIbKrJWixoEmn6KCjKE9PElnrSDSXETGZfPb8ee+nQNTobXkCVvVLytp2o0obAsxl78Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.36.0':
-    resolution: {integrity: sha512-V4GP96thDnpKx6ADnMDnhIXNdtV+Ql9D4HUU+a37VTeVbs5qQSF/s6hhUP1b3xUqU7iRcwh72jUU2Y12rtGHAw==}
+  '@oxfmt/binding-darwin-x64@0.40.0':
+    resolution: {integrity: sha512-fzowhqbOE/NRy+AE5ob0+Y4X243WbWzDb00W+pKwD7d9tOqsAFbtWUwIyqqCoCLxj791m2xXIEeLH/3uz7zCCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.36.0':
-    resolution: {integrity: sha512-/xapWCADfI5wrhxpEUjhI9fnw7MV5BUZizVa8e24n3VSK6A3Y1TB/ClOP1tfxNspykFKXp4NBWl6NtDJP3osqQ==}
+  '@oxfmt/binding-freebsd-x64@0.40.0':
+    resolution: {integrity: sha512-agZ9ITaqdBjcerRRFEHB8s0OyVcQW8F9ZxsszjxzeSthQ4fcN2MuOtQFWec1ed8/lDa50jSLHVE2/xPmTgtCfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.36.0':
-    resolution: {integrity: sha512-1lOmv61XMFIH5uNm27620kRRzWt/RK6tdn250BRDoG9W7OXGOQ5UyI1HVT+SFkoOoKztBiinWgi68+NA1MjBVQ==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.40.0':
+    resolution: {integrity: sha512-ZM2oQ47p28TP1DVIp7HL1QoMUgqlBFHey0ksHct7tMXoU5BqjNvPWw7888azzMt25lnyPODVuye1wvNbvVUFOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.36.0':
-    resolution: {integrity: sha512-vMH23AskdR1ujUS9sPck2Df9rBVoZUnCVY86jisILzIQ/QQ/yKUTi7tgnIvydPx7TyB/48wsQ5QMr5Knq5p/aw==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.40.0':
+    resolution: {integrity: sha512-RBFPAxRAIsMisKM47Oe6Lwdv6agZYLz02CUhVCD1sOv5ajAcRMrnwCFBPWwGXpazToW2mjnZxFos8TuFjTU15A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.36.0':
-    resolution: {integrity: sha512-Hy1V+zOBHpBiENRx77qrUTt5aPDHeCASRc8K5KwwAHkX2AKP0nV89eL17hsZrE9GmnXFjsNmd80lyf7aRTXsbw==}
+  '@oxfmt/binding-linux-arm64-gnu@0.40.0':
+    resolution: {integrity: sha512-Nb2XbQ+wV3W2jSIihXdPj7k83eOxeSgYP3N/SRXvQ6ZYPIk6Q86qEh5Gl/7OitX3bQoQrESqm1yMLvZV8/J7dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.36.0':
-    resolution: {integrity: sha512-SPGLJkOIHSIC6ABUQ5V8NqJpvYhMJueJv26NYqfCnwi/Mn6A61amkpJJ9Suy0Nmvs+OWESJpcebrBUbXPGZyQQ==}
+  '@oxfmt/binding-linux-arm64-musl@0.40.0':
+    resolution: {integrity: sha512-tGmWhLD/0YMotCdfezlT6tC/MJG/wKpo4vnQ3Cq+4eBk/BwNv7EmkD0VkD5F/dYkT3b8FNU01X2e8vvJuWoM1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
-    resolution: {integrity: sha512-3EuoyB8x9x8ysYJjbEO/M9fkSk72zQKnXCvpZMDHXlnY36/1qMp55Nm0PrCwjGO/1pen5hdOVkz9WmP3nAp2IQ==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.40.0':
+    resolution: {integrity: sha512-rVbFyM3e7YhkVnp0IVYjaSHfrBWcTRWb60LEcdNAJcE2mbhTpbqKufx0FrhWfoxOrW/+7UJonAOShoFFLigDqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
-    resolution: {integrity: sha512-MpY3itLwpGh8dnywtrZtaZ604T1m715SydCKy0+qTxetv+IHzuA+aO/AGzrlzUNYZZmtWtmDBrChZGibvZxbRQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.40.0':
+    resolution: {integrity: sha512-3ZqBw14JtWeEoLiioJcXSJz8RQyPE+3jLARnYM1HdPzZG4vk+Ua8CUupt2+d+vSAvMyaQBTN2dZK+kbBS/j5mA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.36.0':
-    resolution: {integrity: sha512-mmDhe4Vtx+XwQPRPn/V25+APnkApYgZ23q+6GVsNYY98pf3aU0aI3Me96pbRs/AfJ1jIiGC+/6q71FEu8dHcHw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.40.0':
+    resolution: {integrity: sha512-JJ4PPSdcbGBjPvb+O7xYm2FmAsKCyuEMYhqatBAHMp/6TA6rVlf9Z/sYPa4/3Bommb+8nndm15SPFRHEPU5qFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.36.0':
-    resolution: {integrity: sha512-AYXhU+DmNWLSnvVwkHM92fuYhogtVHab7UQrPNaDf1sxadugg9gWVmcgJDlIwxJdpk5CVW/TFvwUKwI432zhhA==}
+  '@oxfmt/binding-linux-s390x-gnu@0.40.0':
+    resolution: {integrity: sha512-Kp0zNJoX9Ik77wUya2tpBY3W9f40VUoMQLWVaob5SgCrblH/t2xr/9B2bWHfs0WCefuGmqXcB+t0Lq77sbBmZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.36.0':
-    resolution: {integrity: sha512-H16QhhQ3usoakMleiAAQ2mg0NsBDAdyE9agUgfC8IHHh3jZEbr0rIKwjEqwbOHK5M0EmfhJmr+aGO/MgZPsneA==}
+  '@oxfmt/binding-linux-x64-gnu@0.40.0':
+    resolution: {integrity: sha512-7YTCNzleWTaQTqNGUNQ66qVjpoV6DjbCOea+RnpMBly2bpzrI/uu7Rr+2zcgRfNxyjXaFTVQKaRKjqVdeUfeVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.36.0':
-    resolution: {integrity: sha512-EFFGkixA39BcmHiCe2ECdrq02D6FCve5ka6ObbvrheXl4V+R0U/E+/uLyVx1X65LW8TA8QQHdnbdDallRekohw==}
+  '@oxfmt/binding-linux-x64-musl@0.40.0':
+    resolution: {integrity: sha512-hWnSzJ0oegeOwfOEeejYXfBqmnRGHusgtHfCPzmvJvHTwy1s3Neo59UKc1CmpE3zxvrCzJoVHos0rr97GHMNPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.36.0':
-    resolution: {integrity: sha512-zr/t369wZWFOj1qf06Z5gGNjFymfUNDrxKMmr7FKiDRVI1sNsdKRCuRL4XVjtcptKQ+ao3FfxLN1vrynivmCYg==}
+  '@oxfmt/binding-openharmony-arm64@0.40.0':
+    resolution: {integrity: sha512-28sJC1lR4qtBJGzSRRbPnSW3GxU2+4YyQFE6rCmsUYqZ5XYH8jg0/w+CvEzQ8TuAQz5zLkcA25nFQGwoU0PT3Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.36.0':
-    resolution: {integrity: sha512-FxO7UksTv8h4olzACgrqAXNF6BP329+H322323iDrMB5V/+a1kcAw07fsOsUmqNrb9iJBsCQgH/zqcqp5903ag==}
+  '@oxfmt/binding-win32-arm64-msvc@0.40.0':
+    resolution: {integrity: sha512-cDkRnyT0dqwF5oIX1Cv59HKCeZQFbWWdUpXa3uvnHFT2iwYSSZspkhgjXjU6iDp5pFPaAEAe9FIbMoTgkTmKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.36.0':
-    resolution: {integrity: sha512-OjoMQ89H01M0oLMfr/CPNH1zi48ZIwxAKObUl57oh7ssUBNDp/2Vjf7E1TQ8M4oj4VFQ/byxl2SmcPNaI2YNDg==}
+  '@oxfmt/binding-win32-ia32-msvc@0.40.0':
+    resolution: {integrity: sha512-7rPemBJjqm5Gkv6ZRCPvK8lE6AqQ/2z31DRdWazyx2ZvaSgL7QGofHXHNouRpPvNsT9yxRNQJgigsWkc+0qg4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.36.0':
-    resolution: {integrity: sha512-MoyeQ9S36ZTz/4bDhOKJgOBIDROd4dQ5AkT9iezhEaUBxAPdNX9Oq0jD8OSnCj3G4wam/XNxVWKMA52kmzmPtQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.40.0':
+    resolution: {integrity: sha512-/Zmj0yTYSvmha6TG1QnoLqVT7ZMRDqXvFXXBQpIjteEwx9qvUYMBH2xbiOFhDeMUJkGwC3D6fdKsFtaqUvkwNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.15.0':
-    resolution: {integrity: sha512-d7Ch+A6hic+RYrm32+Gh1o4lOrQqnFsHi721ORdHUDBiQPea+dssKUEMwIbA6MKmCy6TVJ02sQyi24OEfCiGzw==}
+  '@oxlint-tsgolint/darwin-arm64@0.16.0':
+    resolution: {integrity: sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.15.0':
-    resolution: {integrity: sha512-Aoai2wAkaUJqp/uEs1gml6TbaPW4YmyO5Ai/vOSkiizgHqVctjhjKqmRiWTX2xuPY94VkwOLqp+Qr3y/0qSpWQ==}
+  '@oxlint-tsgolint/darwin-x64@0.16.0':
+    resolution: {integrity: sha512-VJo29XOzdkalvCTiE2v6FU3qZlgHaM8x8hUEVJGPU2i5W+FlocPpmn00+Ld2n7Q0pqIjyD5EyvZ5UmoIEJMfqg==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.15.0':
-    resolution: {integrity: sha512-4og13a7ec4Vku5t2Y7s3zx6YJP6IKadb1uA9fOoRH6lm/wHWoCnxjcfJmKHXRZJII81WmbdJMSPxaBfwN/S68Q==}
+  '@oxlint-tsgolint/linux-arm64@0.16.0':
+    resolution: {integrity: sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.15.0':
-    resolution: {integrity: sha512-9b9xzh/1Harn3a+XiKTK/8LrWw3VcqLfYp/vhV5/zAVR2Mt0d63WSp4FL+wG7DKnI2T/CbMFUFHwc7kCQjDMzQ==}
+  '@oxlint-tsgolint/linux-x64@0.16.0':
+    resolution: {integrity: sha512-XQSwVUsnwLokMhe1TD6IjgvW5WMTPzOGGkdFDtXWQmlN2YeTw94s/NN0KgDrn2agM1WIgAenEkvnm0u7NgwEyw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.15.0':
-    resolution: {integrity: sha512-nNac5hewHdkk5mowOwTqB1ZD76zB/FsUiyUvdCyupq5cG54XyKqSLEp9QGbx7wFJkWCkeWmuwRed4sfpAlKaeA==}
+  '@oxlint-tsgolint/win32-arm64@0.16.0':
+    resolution: {integrity: sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.15.0':
-    resolution: {integrity: sha512-ioAY2XLpy83E2EqOLH9p1cEgj0G2qB1lmAn0a3yFV1jHQB29LIPIKGNsu/tYCClpwmHN79pT5KZAHZOgWxxqNg==}
+  '@oxlint-tsgolint/win32-x64@0.16.0':
+    resolution: {integrity: sha512-1ufk8cgktXJuJZHKF63zCHAkaLMwZrEXnZ89H2y6NO85PtOXqu4zbdNl0VBpPP3fCUuUBu9RvNqMFiv0VsbXWA==}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.51.0':
-    resolution: {integrity: sha512-jJYIqbx4sX+suIxWstc4P7SzhEwb4ArWA2KVrmEuu9vH2i0qM6QIHz/ehmbGE4/2fZbpuMuBzTl7UkfNoqiSgw==}
+  '@oxlint/binding-android-arm-eabi@1.55.0':
+    resolution: {integrity: sha512-NhvgAhncTSOhRahQSCnkK/4YIGPjTmhPurQQ2dwt2IvwCMTvZRW5vF2K10UBOxFve4GZDMw6LtXZdC2qeuYIVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.51.0':
-    resolution: {integrity: sha512-GtXyBCcH4ti98YdiMNCrpBNGitx87EjEWxevnyhcBK12k/Vu4EzSB45rzSC4fGFUD6sQgeaxItRCEEWeVwPafw==}
+  '@oxlint/binding-android-arm64@1.55.0':
+    resolution: {integrity: sha512-P9iWRh+Ugqhg+D7rkc7boHX8o3H2h7YPcZHQIgvVBgnua5tk4LR2L+IBlreZs58/95cd2x3/004p5VsQM9z4SA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.51.0':
-    resolution: {integrity: sha512-3QJbeYaMHn6Bh2XeBXuITSsbnIctyTjvHf5nRjKYrT9pPeErNIpp5VDEeAXC0CZSwSVTsc8WOSDwgrAI24JolQ==}
+  '@oxlint/binding-darwin-arm64@1.55.0':
+    resolution: {integrity: sha512-esakkJIt7WFAhT30P/Qzn96ehFpzdZ1mNuzpOb8SCW7lI4oB8VsyQnkSHREM671jfpuBb/o2ppzBCx5l0jpgMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.51.0':
-    resolution: {integrity: sha512-NzErhMaTEN1cY0E8C5APy74lw5VwsNfJfVPBMWPVQLqAbO0k4FFLjvHURvkUL+Y18Wu+8Vs1kbqPh2hjXYA4pg==}
+  '@oxlint/binding-darwin-x64@1.55.0':
+    resolution: {integrity: sha512-xDMFRCCAEK9fOH6As2z8ELsC+VDGSFRHwIKVSilw+xhgLwTDFu37rtmRbmUlx8rRGS6cWKQPTc47AVxAZEVVPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.51.0':
-    resolution: {integrity: sha512-msAIh3vPAoKoHlOE/oe6Q5C/n9umypv/k81lED82ibrJotn+3YG2Qp1kiR8o/Dg5iOEU97c6tl0utxcyFenpFw==}
+  '@oxlint/binding-freebsd-x64@1.55.0':
+    resolution: {integrity: sha512-mYZqnwUD7ALCRxGenyLd1uuG+rHCL+OTT6S8FcAbVm/ZT2AZMGjvibp3F6k1SKOb2aeqFATmwRykrE41Q0GWVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
-    resolution: {integrity: sha512-CqQPcvqYyMe9ZBot2stjGogEzk1z8gGAngIX7srSzrzexmXixwVxBdFZyxTVM0CjGfDeV+Ru0w25/WNjlMM2Hw==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.55.0':
+    resolution: {integrity: sha512-LcX6RYcF9vL9ESGwJW3yyIZ/d/ouzdOKXxCdey1q0XJOW1asrHsIg5MmyKdEBR4plQx+shvYeQne7AzW5f3T1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
-    resolution: {integrity: sha512-dstrlYQgZMnyOssxSbolGCge/sDbko12N/35RBNuqLpoPbft2aeBidBAb0dvQlyBd9RJ6u8D4o4Eh8Un6iTgyQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.55.0':
+    resolution: {integrity: sha512-C+8GS1rPtK+dI7mJFkqoRBkDuqbrNihnyYQsJPS9ez+8zF9JzfvU19lawqt4l/Y23o5uQswE/DORa8aiXUih3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.51.0':
-    resolution: {integrity: sha512-QEjUpXO7d35rP1/raLGGbAsBLLGZIzV3ZbeSjqWlD3oRnxpRIZ6iL4o51XQHkconn3uKssc+1VKdtHJ81BBhDA==}
+  '@oxlint/binding-linux-arm64-gnu@1.55.0':
+    resolution: {integrity: sha512-ErLE4XbmcCopA4/CIDiH6J1IAaDOMnf/KSx/aFObs4/OjAAM3sFKWGZ57pNOMxhhyBdcmcXwYymph9GwcpcqgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.51.0':
-    resolution: {integrity: sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ==}
+  '@oxlint/binding-linux-arm64-musl@1.55.0':
+    resolution: {integrity: sha512-/kp65avi6zZfqEng56TTuhiy3P/3pgklKIdf38yvYeJ9/PgEeRA2A2AqKAKbZBNAqUzrzHhz9jF6j/PZvhJzTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
-    resolution: {integrity: sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q==}
+  '@oxlint/binding-linux-ppc64-gnu@1.55.0':
+    resolution: {integrity: sha512-A6pTdXwcEEwL/nmz0eUJ6WxmxcoIS+97GbH96gikAyre3s5deC7sts38ZVVowjS2QQFuSWkpA4ZmQC0jZSNvJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
-    resolution: {integrity: sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA==}
+  '@oxlint/binding-linux-riscv64-gnu@1.55.0':
+    resolution: {integrity: sha512-clj0lnIN+V52G9tdtZl0LbdTSurnZ1NZj92Je5X4lC7gP5jiCSW+Y/oiDiSauBAD4wrHt2S7nN3pA0zfKYK/6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.51.0':
-    resolution: {integrity: sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg==}
+  '@oxlint/binding-linux-riscv64-musl@1.55.0':
+    resolution: {integrity: sha512-NNu08pllN5x/O94/sgR3DA8lbrGBnTHsINZZR0hcav1sj79ksTiKKm1mRzvZvacwQ0hUnGinFo+JO75ok2PxYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.51.0':
-    resolution: {integrity: sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A==}
+  '@oxlint/binding-linux-s390x-gnu@1.55.0':
+    resolution: {integrity: sha512-BvfQz3PRlWZRoEZ17dZCqgQsMRdpzGZomJkVATwCIGhHVVeHJMQdmdXPSjcT1DCNUrOjXnVyj1RGDj5+/Je2+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.51.0':
-    resolution: {integrity: sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g==}
+  '@oxlint/binding-linux-x64-gnu@1.55.0':
+    resolution: {integrity: sha512-ngSOoFCSBMKVQd24H8zkbcBNc7EHhjnF1sv3mC9NNXQ/4rRjI/4Dj9+9XoDZeFEkF1SX1COSBXF1b2Pr9rqdEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.51.0':
-    resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
+  '@oxlint/binding-linux-x64-musl@1.55.0':
+    resolution: {integrity: sha512-BDpP7W8GlaG7BR6QjGZAleYzxoyKc/D24spZIF2mB3XsfALQJJT/OBmP8YpeTb1rveFSBHzl8T7l0aqwkWNdGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.51.0':
-    resolution: {integrity: sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w==}
+  '@oxlint/binding-openharmony-arm64@1.55.0':
+    resolution: {integrity: sha512-PS6GFvmde/pc3fCA2Srt51glr8Lcxhpf6WIBFfLphndjRrD34NEcses4TSxQrEcxYo6qVywGfylM0ZhSCF2gGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.51.0':
-    resolution: {integrity: sha512-JEZyah1M0RHMw8d+jjSSJmSmO8sABA1J1RtrHYujGPeCkYg1NeH0TGuClpe2h5QtioRTaF57y/TZfn/2IFV6fA==}
+  '@oxlint/binding-win32-arm64-msvc@1.55.0':
+    resolution: {integrity: sha512-P6JcLJGs/q1UOvDLzN8otd9JsH4tsuuPDv+p7aHqHM3PrKmYdmUvkNj4K327PTd35AYcznOCN+l4ZOaq76QzSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.51.0':
-    resolution: {integrity: sha512-q3cEoKH6kwjz/WRyHwSf0nlD2F5Qw536kCXvmlSu+kaShzgrA0ojmh45CA81qL+7udfCaZL2SdKCZlLiGBVFlg==}
+  '@oxlint/binding-win32-ia32-msvc@1.55.0':
+    resolution: {integrity: sha512-gzkk4zE2zsE+WmRxFOiAZHpCpUNDFytEakqNXoNHW+PnYEOTPKDdW6nrzgSeTbGKVPXNAKQnRnMgrh7+n3Xueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.51.0':
-    resolution: {integrity: sha512-Q14+fOGb9T28nWF/0EUsYqERiRA7cl1oy4TJrGmLaqhm+aO2cV+JttboHI3CbdeMCAyDI1+NoSlrM7Melhp/cw==}
+  '@oxlint/binding-win32-x64-msvc@1.55.0':
+    resolution: {integrity: sha512-ZFALNow2/og75gvYzNP7qe+rREQ5xunktwA+lgykoozHZ6hw9bqg4fn5j2UvG4gIn1FXqrZHkOAXuPf5+GOYTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -725,8 +729,17 @@ packages:
     resolution: {integrity: sha512-9YJxzzHftlW936E5z9aEKK2CrPfUgc3HgZ2keyQ5e2Pb5bx+6tykYQ2Gyudvxd7Sxmlnar7SemDMFfx0OuVuGA==}
     engines: {node: '>=20', pnpm: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/dom-mediacapture-transform@0.1.11':
     resolution: {integrity: sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==}
@@ -742,6 +755,129 @@ packages:
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@voidzero-dev/vite-plus-core@0.1.11':
+    resolution: {integrity: sha512-feyYRSg3u8acYNC1fF4EGfgYZm2efZB8YWTjz4NrU0Ulhlni1C6COMwHSDVpu9F4Jh+WcSsBWL3ZC1WvLa7jCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.21.2
+      '@tsdown/exe': 0.21.2
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      publint: ^0.3.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0
+      unplugin-unused: ^0.5.0
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      yaml:
+        optional: true
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.11':
+    resolution: {integrity: sha512-ENokEkMhDMJ9nM/tUDAXvtah/P3cAnEbkeKCCxJgFvTTGnGM8eBvP2qpJeTrfhy9ndIWihcsfMufszinLsfhUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.11':
+    resolution: {integrity: sha512-gOSGYtXq5qigDsiW+oCrefv4K8WUSnZ5vH+kPHDvpsMXlqxR0rY6xrJgkJ2tCkWdCig8YHVDascSV/cj4nGwsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.11':
+    resolution: {integrity: sha512-aDVe1vvhtXBqZdmCiCSm3DUl5/O+x5CeAcjPPTLSsEX79cSfvkD0UU26lQ8eX+pr3xVDEocJTtTLmOMVImGlyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.11':
+    resolution: {integrity: sha512-rkaKCGq/CFML2M7c0ixUOuhE6qi961x84/ZFQhkUy2MJw3RP7R/M1BDyWr2qEq20SgRWLkffcWMni3P2JnmrBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@voidzero-dev/vite-plus-test@0.1.11':
+    resolution: {integrity: sha512-3kBfi/LyPOGnLCmvYtgM5GZVAyiJiYjgdm9Fu9WLLl56zcSljj0TBG19eaKY6v/j2VJ+7o80n/A/MPz46lzMFA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.11':
+    resolution: {integrity: sha512-MerozzH8QYY+V5l6ZQq+vrtx75rnPlmc+TauH5hL08oEWx7ScwfrNKyamnv5rg7HWBx/ryuaYaJCjODOu7MjSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.11':
+    resolution: {integrity: sha512-ubGlfvkfWT4Eivg3O2lxMyA6h7u1XZm4XdW3MUZIXXd9Q/iIRVJdSsEg78C/OZ3e8Qofszsro6P8ZrQo8ROQxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -806,6 +942,10 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -828,6 +968,10 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -841,6 +985,10 @@ packages:
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
@@ -853,6 +1001,10 @@ packages:
       supports-color:
         optional: true
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
@@ -860,6 +1012,9 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -946,6 +1101,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -957,6 +1115,80 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -983,6 +1215,10 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -998,17 +1234,20 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  oxfmt@0.36.0:
-    resolution: {integrity: sha512-/ejJ+KoSW6J9bcNT9a9UtJSJNWhJ3yOLSBLbkoFHJs/8CZjmaZVZAJe4YgO1KMJlKpNQasrn/G9JQUEZI3p0EQ==}
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oxfmt@0.40.0:
+    resolution: {integrity: sha512-g0C3I7xUj4b4DcagevM9kgH6+pUHytikxUcn3/VUkvzTNaaXBeyZqb7IBsHwojeXm4mTBEC/aBjBTMVUkZwWUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.15.0:
-    resolution: {integrity: sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw==}
+  oxlint-tsgolint@0.16.0:
+    resolution: {integrity: sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==}
     hasBin: true
 
-  oxlint@1.51.0:
-    resolution: {integrity: sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ==}
+  oxlint@1.55.0:
+    resolution: {integrity: sha512-T+FjepiyWpaZMhekqRpH8Z3I4vNM610p6w+Vjfqgj5TZUxHXl7N8N5IPvmOU8U4XdTRxqtNNTh9Y4hLtr7yvFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1023,6 +1262,10 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1041,11 +1284,19 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pixelmatch@7.1.0:
+    resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
+    hasBin: true
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1077,6 +1328,18 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1091,6 +1354,9 @@ packages:
   stackblur-canvas@3.0.0:
     resolution: {integrity: sha512-BTbpAj0SNgpTwqKS3aacbI8p3/Ix50i8jAKome/YnM29DZVgriOZ+3V5GAf73nukjZY7xTf0TxdTgFKh4vsAKQ==}
     engines: {node: '>=0.1.16'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1108,6 +1374,13 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -1119,6 +1392,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -1155,48 +1432,30 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite-plus@0.1.11:
+    resolution: {integrity: sha512-mDUbWirSUWtS/diQiq1QkHGsMNQWu90kSH5s7RWqVnV9s1PRxQ1IcH6mIeOG7YzPJlfO1vQbONZRsOfdyj9IKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -1339,137 +1598,143 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.36.0':
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.40.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.36.0':
+  '@oxfmt/binding-android-arm64@0.40.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.36.0':
+  '@oxfmt/binding-darwin-arm64@0.40.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.36.0':
+  '@oxfmt/binding-darwin-x64@0.40.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.36.0':
+  '@oxfmt/binding-freebsd-x64@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.36.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.36.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.36.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.36.0':
+  '@oxfmt/binding-linux-arm64-musl@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.36.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.36.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.36.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.36.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.36.0':
+  '@oxfmt/binding-linux-x64-gnu@0.40.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.36.0':
+  '@oxfmt/binding-linux-x64-musl@0.40.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.36.0':
+  '@oxfmt/binding-openharmony-arm64@0.40.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.36.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.40.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.36.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.40.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.36.0':
+  '@oxfmt/binding-win32-x64-msvc@0.40.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+  '@oxlint-tsgolint/darwin-arm64@0.16.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.15.0':
+  '@oxlint-tsgolint/darwin-x64@0.16.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.15.0':
+  '@oxlint-tsgolint/linux-arm64@0.16.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.15.0':
+  '@oxlint-tsgolint/linux-x64@0.16.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.15.0':
+  '@oxlint-tsgolint/win32-arm64@0.16.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.15.0':
+  '@oxlint-tsgolint/win32-x64@0.16.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.51.0':
+  '@oxlint/binding-android-arm-eabi@1.55.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.51.0':
+  '@oxlint/binding-android-arm64@1.55.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.51.0':
+  '@oxlint/binding-darwin-arm64@1.55.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.51.0':
+  '@oxlint/binding-darwin-x64@1.55.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.51.0':
+  '@oxlint/binding-freebsd-x64@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.51.0':
+  '@oxlint/binding-linux-arm64-gnu@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.51.0':
+  '@oxlint/binding-linux-arm64-musl@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.51.0':
+  '@oxlint/binding-linux-riscv64-musl@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.51.0':
+  '@oxlint/binding-linux-s390x-gnu@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.51.0':
+  '@oxlint/binding-linux-x64-gnu@1.55.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.51.0':
+  '@oxlint/binding-linux-x64-musl@1.55.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.51.0':
+  '@oxlint/binding-openharmony-arm64@1.55.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.51.0':
+  '@oxlint/binding-win32-arm64-msvc@1.55.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.51.0':
+  '@oxlint/binding-win32-ia32-msvc@1.55.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.51.0':
+  '@oxlint/binding-win32-x64-msvc@1.55.0':
     optional: true
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -1595,7 +1860,16 @@ snapshots:
 
   '@shiguredo/rnnoise-wasm@2025.1.5': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/argparse@1.0.38': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/dom-mediacapture-transform@0.1.11':
     dependencies:
@@ -1611,6 +1885,76 @@ snapshots:
     optional: true
 
   '@types/offscreencanvas@2019.7.3': {}
+
+  '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      '@oxc-project/types': 0.115.0
+      lightningcss: 1.32.0
+      postcss: 8.5.8
+    optionalDependencies:
+      '@types/node': 22.15.17
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+      typescript: 5.9.3
+      yaml: 2.8.0
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.11':
+    optional: true
+
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.11':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.11':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.11':
+    optional: true
+
+  '@voidzero-dev/vite-plus-test@0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
+      ws: 8.19.0
+    optionalDependencies:
+      '@types/node': 22.15.17
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - yaml
+
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.11':
+    optional: true
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.11':
+    optional: true
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -1685,6 +2029,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -1702,6 +2048,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  cac@6.7.14: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -1721,15 +2069,25 @@ snapshots:
 
   confbox@0.2.4: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   de-indent@1.0.2: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  detect-libc@2.1.2: {}
+
   diff@8.0.3: {}
 
   entities@7.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1759,6 +2117,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+    optional: true
 
   estree-walker@2.0.2: {}
 
@@ -1819,6 +2178,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  isexe@2.0.0: {}
+
   jju@1.4.0: {}
 
   json-schema-traverse@1.0.0: {}
@@ -1830,6 +2191,55 @@ snapshots:
       graceful-fs: 4.2.11
 
   kolorist@1.8.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   local-pkg@1.1.2:
     dependencies:
@@ -1862,6 +2272,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
@@ -1870,65 +2282,69 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  oxfmt@0.36.0:
+  obug@2.1.1: {}
+
+  oxfmt@0.40.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.36.0
-      '@oxfmt/binding-android-arm64': 0.36.0
-      '@oxfmt/binding-darwin-arm64': 0.36.0
-      '@oxfmt/binding-darwin-x64': 0.36.0
-      '@oxfmt/binding-freebsd-x64': 0.36.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.36.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.36.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.36.0
-      '@oxfmt/binding-linux-arm64-musl': 0.36.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.36.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.36.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.36.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.36.0
-      '@oxfmt/binding-linux-x64-gnu': 0.36.0
-      '@oxfmt/binding-linux-x64-musl': 0.36.0
-      '@oxfmt/binding-openharmony-arm64': 0.36.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.36.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.36.0
-      '@oxfmt/binding-win32-x64-msvc': 0.36.0
+      '@oxfmt/binding-android-arm-eabi': 0.40.0
+      '@oxfmt/binding-android-arm64': 0.40.0
+      '@oxfmt/binding-darwin-arm64': 0.40.0
+      '@oxfmt/binding-darwin-x64': 0.40.0
+      '@oxfmt/binding-freebsd-x64': 0.40.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.40.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.40.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.40.0
+      '@oxfmt/binding-linux-arm64-musl': 0.40.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.40.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.40.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.40.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.40.0
+      '@oxfmt/binding-linux-x64-gnu': 0.40.0
+      '@oxfmt/binding-linux-x64-musl': 0.40.0
+      '@oxfmt/binding-openharmony-arm64': 0.40.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.40.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.40.0
+      '@oxfmt/binding-win32-x64-msvc': 0.40.0
 
-  oxlint-tsgolint@0.15.0:
+  oxlint-tsgolint@0.16.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.15.0
-      '@oxlint-tsgolint/darwin-x64': 0.15.0
-      '@oxlint-tsgolint/linux-arm64': 0.15.0
-      '@oxlint-tsgolint/linux-x64': 0.15.0
-      '@oxlint-tsgolint/win32-arm64': 0.15.0
-      '@oxlint-tsgolint/win32-x64': 0.15.0
+      '@oxlint-tsgolint/darwin-arm64': 0.16.0
+      '@oxlint-tsgolint/darwin-x64': 0.16.0
+      '@oxlint-tsgolint/linux-arm64': 0.16.0
+      '@oxlint-tsgolint/linux-x64': 0.16.0
+      '@oxlint-tsgolint/win32-arm64': 0.16.0
+      '@oxlint-tsgolint/win32-x64': 0.16.0
 
-  oxlint@1.51.0(oxlint-tsgolint@0.15.0):
+  oxlint@1.55.0(oxlint-tsgolint@0.16.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.51.0
-      '@oxlint/binding-android-arm64': 1.51.0
-      '@oxlint/binding-darwin-arm64': 1.51.0
-      '@oxlint/binding-darwin-x64': 1.51.0
-      '@oxlint/binding-freebsd-x64': 1.51.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.51.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.51.0
-      '@oxlint/binding-linux-arm64-gnu': 1.51.0
-      '@oxlint/binding-linux-arm64-musl': 1.51.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.51.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.51.0
-      '@oxlint/binding-linux-riscv64-musl': 1.51.0
-      '@oxlint/binding-linux-s390x-gnu': 1.51.0
-      '@oxlint/binding-linux-x64-gnu': 1.51.0
-      '@oxlint/binding-linux-x64-musl': 1.51.0
-      '@oxlint/binding-openharmony-arm64': 1.51.0
-      '@oxlint/binding-win32-arm64-msvc': 1.51.0
-      '@oxlint/binding-win32-ia32-msvc': 1.51.0
-      '@oxlint/binding-win32-x64-msvc': 1.51.0
-      oxlint-tsgolint: 0.15.0
+      '@oxlint/binding-android-arm-eabi': 1.55.0
+      '@oxlint/binding-android-arm64': 1.55.0
+      '@oxlint/binding-darwin-arm64': 1.55.0
+      '@oxlint/binding-darwin-x64': 1.55.0
+      '@oxlint/binding-freebsd-x64': 1.55.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.55.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.55.0
+      '@oxlint/binding-linux-arm64-gnu': 1.55.0
+      '@oxlint/binding-linux-arm64-musl': 1.55.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.55.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.55.0
+      '@oxlint/binding-linux-riscv64-musl': 1.55.0
+      '@oxlint/binding-linux-s390x-gnu': 1.55.0
+      '@oxlint/binding-linux-x64-gnu': 1.55.0
+      '@oxlint/binding-linux-x64-musl': 1.55.0
+      '@oxlint/binding-openharmony-arm64': 1.55.0
+      '@oxlint/binding-win32-arm64-msvc': 1.55.0
+      '@oxlint/binding-win32-ia32-msvc': 1.55.0
+      '@oxlint/binding-win32-x64-msvc': 1.55.0
+      oxlint-tsgolint: 0.16.0
 
   p-map@7.0.4: {}
 
   path-browserify@1.0.1: {}
+
+  path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
@@ -1939,6 +2355,10 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pixelmatch@7.1.0:
+    dependencies:
+      pngjs: 7.0.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -1951,6 +2371,8 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.8:
     dependencies:
@@ -2002,10 +2424,23 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+    optional: true
 
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   source-map-js@1.2.1: {}
 
@@ -2014,6 +2449,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackblur-canvas@3.0.0: {}
+
+  std-env@4.0.0: {}
 
   string-argv@0.3.2: {}
 
@@ -2024,6 +2461,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -2036,6 +2477,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   typescript@5.8.2: {}
 
   typescript@5.9.3: {}
@@ -2047,7 +2490,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  vite-plugin-dts@4.5.4(@types/node@22.15.17)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.15.17)(yaml@2.8.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(rollup@4.59.0)(typescript@5.9.3):
     dependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@22.15.17)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -2060,34 +2503,73 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.15.17)(yaml@2.8.0)
+      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-static-copy@3.2.0(vite@7.3.1(@types/node@22.15.17)(yaml@2.8.0)):
+  vite-plugin-static-copy@3.2.0(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.15.17)(yaml@2.8.0)
+      vite: '@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)'
 
-  vite@7.3.1(@types/node@22.15.17)(yaml@2.8.0):
+  vite-plus@0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
+      '@oxc-project/types': 0.115.0
+      '@voidzero-dev/vite-plus-core': 0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      '@voidzero-dev/vite-plus-test': 0.1.11(@types/node@22.15.17)(@voidzero-dev/vite-plus-core@0.1.11(@types/node@22.15.17)(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0))(esbuild@0.27.3)(typescript@5.9.3)(yaml@2.8.0)
+      cac: 6.7.14
+      cross-spawn: 7.0.6
+      oxfmt: 0.40.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.16.0)
+      oxlint-tsgolint: 0.16.0
+      picocolors: 1.1.1
     optionalDependencies:
-      '@types/node': 22.15.17
-      fsevents: 2.3.3
-      yaml: 2.8.0
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.11
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.11
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.11
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.11
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.11
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.11
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - vite
+      - yaml
 
   vscode-uri@3.1.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  ws@8.19.0: {}
 
   yallist@4.0.0: {}
 


### PR DESCRIPTION
- vite を npm:@voidzero-dev/vite-plus-core@0.1.11 に変更
- vite-plus 0.1.11 を追加
- oxfmt, oxlint, oxlint-tsgolint を削除
- 全スクリプトを vp コマンドに変更
- defineConfig の import を vite-plus に変更
- .oxfmtrc.jsonc, .oxlintrc.jsonc の $schema を削除
- .oxlintrc.jsonc に overrides を追加して lint エラーを解消
- 不要な @ts-expect-error を削除